### PR TITLE
Setup phpunit-bridge instead of phpunit

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,16 +17,16 @@ jobs:
             phpunit-version: '8.5'
           - php-version: '7.3'
             composer-dependencies: ''
-            phpunit-version: '9.5'
+            phpunit-version: '9.4'
           - php-version: '7.3'
             composer-dependencies: 'lowest'
-            phpunit-version: '9.5'
+            phpunit-version: '9.4'
           - php-version: '7.4'
             composer-dependencies: ''
-            phpunit-version: '9.5'
+            phpunit-version: '9.4'
           - php-version: '7.4'
             composer-dependencies: 'lowest'
-            phpunit-version: '9.5'
+            phpunit-version: '9.4'
     services:
       redis:
         image: redis:6.0.0

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,16 +17,16 @@ jobs:
             phpunit-version: '8.5'
           - php-version: '7.3'
             composer-dependencies: ''
-            phpunit-version: '9.4'
+            phpunit-version: '8.5'
           - php-version: '7.3'
             composer-dependencies: 'lowest'
-            phpunit-version: '9.4'
+            phpunit-version: '8.5'
           - php-version: '7.4'
             composer-dependencies: ''
-            phpunit-version: '9.4'
+            phpunit-version: '8.5'
           - php-version: '7.4'
             composer-dependencies: 'lowest'
-            phpunit-version: '9.4'
+            phpunit-version: '8.5'
     services:
       redis:
         image: redis:6.0.0

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -2,14 +2,31 @@ name: SchedulerBundle - Push
 on: [push, pull_request]
 jobs:
   scheduler_bundle:
-    name: PHP ${{ matrix.php-versions }} - ${{ matrix.composer-dependencies }}
+    name: PHP ${{ matrix.php-version }} - phpunit ${{ matrix.phpunit-version }} - ${{ matrix.composer-dependencies }}
     # https://hub.docker.com/_/ubuntu/
     runs-on: ubuntu-18.04
     strategy:
       fail-fast: true
       matrix:
-        php-versions: ['7.2', '7.3', '7.4']
-        composer-dependencies: ['', 'lowest']
+        include:
+          - php-version: '7.2'
+            composer-dependencies: ''
+            phpunit-version: '8.5'
+          - php-version: '7.2'
+            composer-dependencies: 'lowest'
+            phpunit-version: '8.5'
+          - php-version: '7.3'
+            composer-dependencies: ''
+            phpunit-version: '9.5'
+          - php-version: '7.3'
+            composer-dependencies: 'lowest'
+            phpunit-version: '9.5'
+          - php-version: '7.4'
+            composer-dependencies: ''
+            phpunit-version: '9.5'
+          - php-version: '7.4'
+            composer-dependencies: 'lowest'
+            phpunit-version: '9.5'
     services:
       redis:
         image: redis:6.0.0
@@ -30,7 +47,7 @@ jobs:
       - name: Setup PHP, extensions and composer with shivammathur/setup-php
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
           extensions: zip, xdebug, redis
           coverage: xdebug
         env:
@@ -65,6 +82,20 @@ jobs:
         with:
           args: --dry-run .
 
+      # —— PHPUnit ———————————————————————————————————————————————————————
+      - name: PHPUnit
+        run: php vendor/bin/simple-phpunit tests
+        env:
+          SCHEDULER_REDIS_DSN: redis://127.0.0.1:6379/_symfony_scheduler_tasks
+          SYMFONY_PHPUNIT_VERSION: ${{ matrix.phpunit-version }}
+
+      - name: Cache PHPUnit result
+        uses: actions/cache@v2
+        with:
+          path: ~/.phpunit.result.cache
+          key: ${{ runner.os }}-composer-${{ matrix.php-version }}-${{ matrix.composer-dependencies }}-${{ hashFiles('**/.phpunit.result.cache') }}
+          restore-keys: ${{ runner.os }}-composer-${{ matrix.php-version }}-${{ matrix.composer-dependencies }}-
+
       # —— Rector ————————————————————————————————————————————————————————
       - name: Rector
         run: php vendor/bin/rector process --dry-run --clear-cache
@@ -73,21 +104,9 @@ jobs:
 #      - name: PHPStan
 #        run: php vendor/bin/phpstan analyze
 
-      # —— PHPUnit ———————————————————————————————————————————————————————
-      - name: PHPUnit
-        run: php vendor/bin/phpunit tests
-        env:
-          SCHEDULER_REDIS_DSN: redis://127.0.0.1:6379/_symfony_scheduler_tasks
-
-      - name: Cache PHPUnit result
-        uses: actions/cache@v2
-        with:
-          path: ~/.phpunit.result.cache
-          key: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ matrix.composer-dependencies }}-${{ hashFiles('**/.phpunit.result.cache') }}
-          restore-keys: ${{ runner.os }}-composer-${{ matrix.php-versions }}-${{ matrix.composer-dependencies }}-
-
       # —— Infection —————————————————————————————————————————————————————
       - name: Infection
         run: php vendor/bin/infection --no-progress --min-covered-msi=80 --min-msi=75 --show-mutations --threads=4
         env:
           SCHEDULER_REDIS_DSN: redis://127.0.0.1:6379/_symfony_scheduler_tasks
+          SYMFONY_PHPUNIT_VERSION: ${{ matrix.phpunit-version }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -106,7 +106,7 @@ jobs:
 
       # —— Infection —————————————————————————————————————————————————————
       - name: Infection
-        run: php vendor/bin/infection --no-progress --min-covered-msi=80 --min-msi=75 --show-mutations --threads=4
+        run: php vendor/bin/infection --no-progress --min-covered-msi=80 --min-msi=75 --show-mutations --threads=4 --log-verbosity=all --debug
         env:
           SCHEDULER_REDIS_DSN: redis://127.0.0.1:6379/_symfony_scheduler_tasks
           SYMFONY_PHPUNIT_VERSION: ${{ matrix.phpunit-version }}

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ rector: rector.php
 
 tests: ## Launch the PHPUnit tests
 tests: phpunit.xml.dist
-	$(PHP) vendor/bin/phpunit tests
+	$(PHP) vendor/bin/simple-phpunit tests
 
 infection: ## Launch Infection
 infection: infection.json.dist

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,6 @@
         "phpstan/phpstan": "^0.12",
         "phpstan/phpstan-phpunit": "^0.12",
         "phpstan/phpstan-doctrine": "^0.12",
-        "phpunit/phpunit": "^8.5",
         "psalm/plugin-phpunit": "^0.15",
         "psr/cache": "^1.0",
         "rector/rector": "^0.8.56",
@@ -112,6 +111,7 @@
         "symfony/http-kernel": "^5.2",
         "symfony/messenger": "^5.2",
         "symfony/notifier": "^5.2",
+        "symfony/phpunit-bridge": "^5.2",
         "vimeo/psalm": "^4.4"
     },
     "suggest": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,6 +10,7 @@
 >
     <php>
         <ini name="error_reporting" value="-1" />
+        <server name="SYMFONY_DEPRECATIONS_HELPER" value="quiet[]=indirect" />
     </php>
 
     <testsuites>

--- a/rector.php
+++ b/rector.php
@@ -16,6 +16,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $parameters->set(Option::AUTOLOAD_PATHS, [
         __DIR__ . '/vendor/autoload.php',
+        __DIR__ . '/vendor/bin/.phpunit/phpunit/vendor/autoload.php',
     ]);
 
     $parameters->set(Option::PATHS, [


### PR DESCRIPTION
Use Symfony's phpunit-bridge instead of phpunit. Allows to use a specific phpunit version on some CI runs.

Somehow infection fails while it still succeeds to run the tests.