### PR TITLE
Composer version range: use || instead of |

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,7 @@
         "ext-pcntl": "*",
         "ext-redis": "*",
         "api-platform/core": "^2.6",
-        "doctrine/dbal": "^2.12|^3.0",
+        "doctrine/dbal": "^2.12 || ^3.0",
         "doctrine/orm": "^2.8",
         "friendsofphp/php-cs-fixer": "^2.18",
         "infection/infection": "^0.21",


### PR DESCRIPTION
See:
* https://getcomposer.org/doc/articles/versions.md#version-range
* https://github.com/composer/composer/issues/6755

Officially it seems the double pipe is preferred. I guess the single pipe won't be dropped any time soon, but why not adopt the official way? :)