### PR TITLE
fix(expression): bad timezone

### DIFF
--- a/src/Expression/FluentExpressionBuilder.php
+++ b/src/Expression/FluentExpressionBuilder.php
@@ -16,7 +16,8 @@ final class FluentExpressionBuilder implements ExpressionBuilderInterface
 {
     public function build(string $expression, ?string $timezone = 'UTC'): Expression
     {
-        $date = DateTimeImmutable::createFromFormat('U', (string) strtotime($expression), new DateTimeZone($timezone));
+        $date = DateTimeImmutable::createFromFormat('U', (string) strtotime($expression));
+        $date = $date->setTimezone(new DateTimeZone($timezone));
 
         $expression = new Expression();
         $expression->setExpression(sprintf(

--- a/tests/Expression/FluentExpressionBuilderTest.php
+++ b/tests/Expression/FluentExpressionBuilderTest.php
@@ -62,7 +62,6 @@ final class FluentExpressionBuilderTest extends TestCase
         yield ['12/22/78', '0 0 22 12 5', 'UTC'];
         yield ['10/Oct/2000:13:55:36 -0700', '55 20 10 10 2', 'UTC'];
 
-        // Test with a different timezone
         $datetime = new DateTimeImmutable();
         $datetime = $datetime->setTimezone(new DateTimeZone('Europe/Paris'));
         $datetime = $datetime->modify("+1 minute");

--- a/tests/Expression/FluentExpressionBuilderTest.php
+++ b/tests/Expression/FluentExpressionBuilderTest.php
@@ -33,12 +33,12 @@ final class FluentExpressionBuilderTest extends TestCase
     }
 
     /**
-     * @dataProvider provideExpression
+     * @dataProvider provideExpressionWithTimezone
      */
-    public function testBuilderCanBuildWithTimezone(string $expression, string $endExpression): void
+    public function testBuilderCanBuildWithTimezone(string $expression, string $endExpression, string $timezone): void
     {
         $fluentExpressionBuilder = new FluentExpressionBuilder();
-        $finalExpression = $fluentExpressionBuilder->build($expression);
+        $finalExpression = $fluentExpressionBuilder->build($expression, $timezone);
 
         self::assertSame($finalExpression->getExpression(), $endExpression);
     }
@@ -50,5 +50,31 @@ final class FluentExpressionBuilderTest extends TestCase
         yield ['first day of January 2008', '0 0 1 1 2'];
         yield ['12/22/78', '0 0 22 12 5'];
         yield ['10/Oct/2000:13:55:36 -0700', '55 20 10 10 2'];
+    }
+
+    public function provideExpressionWithTimezone(): Generator
+    {
+        yield ['first monday of January 1980 10:00', '0 10 7 1 1', 'UTC'];
+        yield ['last monday of July 1970 10:00', '0 10 27 7 1', 'UTC'];
+        yield ['first day of January 2008', '0 0 1 1 2', 'UTC'];
+        yield ['12/22/78', '0 0 22 12 5', 'UTC'];
+        yield ['10/Oct/2000:13:55:36 -0700', '55 20 10 10 2', 'UTC'];
+
+        // Test with a different timezone
+        $datetime = new \DateTimeImmutable();
+        $datetime = $datetime->setTimezone(new \DateTimeZone('Europe/Paris'));
+        $datetime = $datetime->modify("+1 minute");
+        yield [
+            $datetime->format(\DateTimeImmutable::RFC3339),
+            sprintf(
+                '%d %s %s %s %s',
+                (int) $datetime->format('i'),
+                $datetime->format('G'),
+                $datetime->format('j'),
+                $datetime->format('n'),
+                $datetime->format('w')
+            ),
+            'Europe/Paris',
+        ];
     }
 }

--- a/tests/Expression/FluentExpressionBuilderTest.php
+++ b/tests/Expression/FluentExpressionBuilderTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Tests\SchedulerBundle\Expression;
 
+use DateTimeImmutable;
+use DateTimeZone;
 use Generator;
 use PHPUnit\Framework\TestCase;
 use SchedulerBundle\Expression\FluentExpressionBuilder;
@@ -61,11 +63,11 @@ final class FluentExpressionBuilderTest extends TestCase
         yield ['10/Oct/2000:13:55:36 -0700', '55 20 10 10 2', 'UTC'];
 
         // Test with a different timezone
-        $datetime = new \DateTimeImmutable();
-        $datetime = $datetime->setTimezone(new \DateTimeZone('Europe/Paris'));
+        $datetime = new DateTimeImmutable();
+        $datetime = $datetime->setTimezone(new DateTimeZone('Europe/Paris'));
         $datetime = $datetime->modify("+1 minute");
         yield [
-            $datetime->format(\DateTimeImmutable::RFC3339),
+            $datetime->format(DateTimeImmutable::RFC3339),
             sprintf(
                 '%d %s %s %s %s',
                 (int) $datetime->format('i'),


### PR DESCRIPTION
Hello,

If you try to set a fluent task in 2 minutes (to midnight #ironmaiden), your first execution will be the next week.

Demo : 

- Create a fluent task with an expression like this **2021-04-22T15:50:00+0200**
- Debug with `bin/console scheduler:list`

```
+---------------+--------------+--------------+---------------------------+---------------------------+-------------------------+-----------------------------+---------+------+
| Name          | Description  | Expression   | Last execution date       | Next execution date       | Last execution duration | Last execution memory usage | State   | Tags |
+---------------+--------------+--------------+---------------------------+---------------------------+-------------------------+-----------------------------+---------+------+
| 60817ee37fa42 | Test de task | 50 13 22 4 4 | Not executed              | 2021-04-29T13:50:00+02:00 | Not tracked             | Not tracked                 | enabled |      |
+---------------+--------------+--------------+---------------------------+---------------------------+-------------------------+-----------------------------+---------+------+
```

If you change the timezone as I do, you will have this : 

```
+---------------+--------------+--------------+---------------------------+---------------------------+-------------------------+-----------------------------+---------+------+
| Name          | Description  | Expression   | Last execution date       | Next execution date       | Last execution duration | Last execution memory usage | State   | Tags |
+---------------+--------------+--------------+---------------------------+---------------------------+-------------------------+-----------------------------+---------+------+
| 60817ee37fa42 | Test de task | 50 13 22 4 4 | Not executed              | 2021-04-22T13:50:00+02:00 | Not tracked             | Not tracked                 | enabled |      |
+---------------+--------------+--------------+---------------------------+---------------------------+-------------------------+-----------------------------+---------+------+
```

I did not write any test and I did not test with other values. I recieve a date from my API with this format.

Thanks

PS : my PHP code 

```php
$fluentExpression = new FluentExpressionBuilder();
$shellBuilder = new ShellBuilder(new ExpressionBuilder([
    $fluentExpression,
]));

$expression = $request->query->get('expression', '');
if (false === $fluentExpression->support($expression)) {
    throw new \Exception("Expression non supportée : $expression");
}

/** @var ShellTask $task */
$task = $shellBuilder->build(PropertyAccess::createPropertyAccessor(), [
    'name' => uniqid(),
    'command' => ['ls', '-al'],
    'expression' => $expression,
    'timezone' => 'Europe/Paris',
    'description' => 'Test de task',
    'single_run' => true,
]);
$this->scheduler->schedule($task);
``` 