### PR TITLE
feat(command): ExecuteTaskCommand introduced

### DIFF
--- a/doc/command.md
+++ b/doc/command.md
@@ -2,20 +2,6 @@
 
 This bundle provides a set of commands to interact with your tasks
 
-## Consuming tasks
-
-_Description: Consume due tasks_
-
-```bash
-$ bin/console scheduler:consume
-```
-
-## Executing tasks
-
-_Introduced in `0.5`_
-
-_Description: Execute a set of tasks (due or not) depending on filters_
-
 ## Listing the tasks
 
 _Description: List every tasks scheduled_
@@ -55,6 +41,30 @@ This command allows using multiple options to filter consumed tasks (each one ca
 - The command filter tasks returned by the scheduler by checking if each task is not paused 
   (the worker will do this if the `--wait` option is set).
 - The output of each executed task can be displayed if the `-vv` option is used.
+
+## Executing tasks
+
+_Introduced in `0.5`_
+
+_Description: Execute a set of tasks (due or not) depending on filters_
+
+```bash
+$ bin/console scheduler:execute
+```
+
+### Options
+
+This command allows using multiple options to filter consumed tasks (each one can be combined):
+
+- `--due`: Execute due tasks.
+- `--namme`: Allows to specify a set of tasks (depending on their name) that must be executed.
+- `--expression`: Allows to specify a set of tasks (depending on their expression) that must be executed.
+- `--tags`: Allows to specify a set of tasks (depending on their tags) that must be executed.
+
+### Extra informations
+
+- Depending on `--due` option, the scheduler will execute the due tasks or each tasks that match the submitted options.
+- The worker is automatically stopped once each task has been consumed.
 
 ## Rebooting the scheduler
 

--- a/doc/command.md
+++ b/doc/command.md
@@ -2,6 +2,20 @@
 
 This bundle provides a set of commands to interact with your tasks
 
+## Consuming tasks
+
+_Description: Consume due tasks_
+
+```bash
+$ bin/console scheduler:consume
+```
+
+## Executing tasks
+
+_Introduced in `0.5`_
+
+_Description: Execute a set of tasks (due or not) depending on filters_
+
 ## Listing the tasks
 
 _Description: List every tasks scheduled_

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -19,6 +19,6 @@
         "@default": true
     },
     "testFramework": "phpunit",
-    "minCoveredMsi": 90,
-    "minMsi": 85
+    "minCoveredMsi": 91,
+    "minMsi": 86
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,7 @@ includes:
     - vendor/phpstan/phpstan-symfony/extension.neon
 
 parameters:
-    level: 5
+    level: 6
     paths:
         - src
         - tests

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,7 @@ includes:
     - vendor/phpstan/phpstan-symfony/extension.neon
 
 parameters:
-    level: 6
+    level: 5
     paths:
         - src
         - tests

--- a/src/Command/ExecuteTaskCommand.php
+++ b/src/Command/ExecuteTaskCommand.php
@@ -101,7 +101,7 @@ final class ExecuteTaskCommand extends Command
             return self::SUCCESS;
         }
 
-        $style->info(sprintf('Found %s task%s', count($tasks), 1 < count($tasks) ? 's' : ''));
+        $style->info(sprintf('Found %d task%s', count($tasks), 1 < count($tasks) ? 's' : ''));
 
         $executionOptions = [];
 
@@ -122,7 +122,7 @@ final class ExecuteTaskCommand extends Command
 
         $style->info([
             'The tasks following the listed conditions will be executed:',
-            implode('' . PHP_EOL, $executionOptions),
+            implode(PHP_EOL, $executionOptions),
             sprintf('%d task%s to be executed', count($tasks), 1 < count($tasks) ? 's' : ''),
         ]);
 

--- a/src/Command/ExecuteTaskCommand.php
+++ b/src/Command/ExecuteTaskCommand.php
@@ -101,7 +101,7 @@ final class ExecuteTaskCommand extends Command
             return self::SUCCESS;
         }
 
-        $style->info(sprintf('Found %d task%s', count($tasks), 1 < count($tasks) ? 's' : ''));
+        $style->info(sprintf('Found %d task%s', count($tasks), 1 !== count($tasks) ? 's' : ''));
 
         $executionOptions = [];
 

--- a/src/Command/ExecuteTaskCommand.php
+++ b/src/Command/ExecuteTaskCommand.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchedulerBundle\Command;
+
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use SchedulerBundle\EventListener\StopWorkerOnTaskLimitSubscriber;
+use SchedulerBundle\SchedulerInterface;
+use SchedulerBundle\Task\TaskInterface;
+use SchedulerBundle\Worker\WorkerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+use function array_walk;
+use function count;
+use function implode;
+use function in_array;
+use function sprintf;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class ExecuteTaskCommand extends Command
+{
+    private EventDispatcherInterface $eventDispatcher;
+    private SchedulerInterface $scheduler;
+    private WorkerInterface $worker;
+    private LoggerInterface $logger;
+
+    /**
+     * @var string|null
+     */
+    protected static $defaultName = 'scheduler:execute';
+
+    public function __construct(
+        EventDispatcherInterface $eventDispatcher,
+        SchedulerInterface $scheduler,
+        WorkerInterface $worker,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->eventDispatcher = $eventDispatcher;
+        $this->scheduler = $scheduler;
+        $this->worker = $worker;
+        $this->logger = $logger ?? new NullLogger();
+
+        parent::__construct();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Execute tasks (due or not) depending on filters')
+            ->setDefinition([
+                new InputOption('due', 'd', InputOption::VALUE_NONE, 'Define if the filters must be applied on due tasks'),
+                new InputOption('name', 'n', InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'The name of the task(s) to execute'),
+                new InputOption('expression', null, InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'The expression of the task(s) to execute'),
+                new InputOption('tags', 't', InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'The tags of the task(s) to execute'),
+            ])
+            ->setHelp(
+                <<<'EOF'
+                    The <info>%command.name%</info> command execute tasks.
+
+                        <info>php %command.full_name%</info>
+
+                    Use the --due option to execute the due tasks:
+                        <info>php %command.full_name% --due</info>
+
+                    Use the --name option to filter the executed tasks depending on their name:
+                        <info>php %command.full_name% --name=foo, bar</info>
+
+                    Use the --expression option to filter the executed tasks depending on their expression:
+                        <info>php %command.full_name% --expression=* * * * *</info>
+
+                    Use the --tags option to filter the executed tasks depending on their tags:
+                        <info>php %command.full_name% --tags=foo, bar</info>
+                    EOF
+            )
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $style = new SymfonyStyle($input, $output);
+
+        $tasks = $input->getOption('due') ? $this->scheduler->getDueTasks() : $this->scheduler->getTasks();
+        if (0 === count($tasks)) {
+            $style->warning('No tasks to execute found');
+
+            return self::SUCCESS;
+        }
+
+        $style->info(sprintf('Found %s task%s', count($tasks), 1 < count($tasks) ? 's' : ''));
+
+        $executionOptions = [];
+
+        if ([] !== $names = $input->getOption('name')) {
+            $executionOptions[] = sprintf('- Task(s) with the following name(s): %s', implode(', ', $names));
+            $tasks = $tasks->filter(fn (TaskInterface $task): bool => in_array($task->getName(), $names, true));
+        }
+
+        if ([] !== $expressions = $input->getOption('expression')) {
+            $executionOptions[] = sprintf('- Task(s) with the following expression(s): %s', implode(', ', $expressions));
+            $tasks = $tasks->filter(fn (TaskInterface $task): bool => in_array($task->getExpression(), $expressions, true));
+        }
+
+        if ([] !== $tags = $input->getOption('tags')) {
+            $executionOptions[] = sprintf('- Task(s) with the following tags(s): %s', implode(', ', $tags));
+            $tasks = $tasks->filter(fn (TaskInterface $task): bool => array_walk($tags, fn (string $tag): bool => in_array($tag, $task->getTags(), true)));
+        }
+
+        $style->info([
+            'The tasks following the listed conditions will be executed:',
+            implode('' . PHP_EOL, $executionOptions),
+            sprintf('%d task%s to be executed', count($tasks), 1 < count($tasks) ? 's' : ''),
+        ]);
+
+        $this->eventDispatcher->dispatch(new StopWorkerOnTaskLimitSubscriber(count($tasks), $this->logger));
+
+        try {
+            $this->worker->execute([], ...$tasks->toArray(false));
+        } catch (Throwable $throwable) {
+            $style->error([
+                'An error occurred during the tasks execution:',
+                $throwable->getMessage(),
+            ]);
+
+            return self::FAILURE;
+        }
+
+        $style->success([
+            sprintf('%d task%s %s been executed', count($tasks), 1 < count($tasks) ? 's' : '', 1 < count($tasks) ? 'have' : 'has'),
+        ]);
+
+        return self::SUCCESS;
+    }
+}

--- a/src/DependencyInjection/SchedulerBundleExtension.php
+++ b/src/DependencyInjection/SchedulerBundleExtension.php
@@ -11,6 +11,7 @@ use SchedulerBundle\Bridge\Doctrine\SchemaListener\SchedulerTransportDoctrineSch
 use SchedulerBundle\Bridge\Doctrine\Transport\DoctrineTransportFactory;
 use SchedulerBundle\Bridge\Redis\Transport\RedisTransportFactory;
 use SchedulerBundle\Command\ConsumeTasksCommand;
+use SchedulerBundle\Command\ExecuteTaskCommand;
 use SchedulerBundle\Command\ListFailedTasksCommand;
 use SchedulerBundle\Command\ListTasksCommand;
 use SchedulerBundle\Command\RebootSchedulerCommand;
@@ -307,6 +308,22 @@ final class SchedulerBundleExtension extends Extension
             ])
             ->addTag('container.preload', [
                 'class' => ConsumeTasksCommand::class,
+            ])
+        ;
+
+        $container->register(ExecuteTaskCommand::class, ExecuteTaskCommand::class)
+            ->setArguments([
+                new Reference(EventDispatcherInterface::class, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE),
+                new Reference(SchedulerInterface::class, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE),
+                new Reference(WorkerInterface::class, ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE),
+                new Reference(LoggerInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE),
+            ])
+            ->addTag('console.command')
+            ->addTag('monolog.logger', [
+                'channel' => 'scheduler',
+            ])
+            ->addTag('container.preload', [
+                'class' => ExecuteTaskCommand::class,
             ])
         ;
 

--- a/src/SchedulerInterface.php
+++ b/src/SchedulerInterface.php
@@ -51,6 +51,8 @@ interface SchedulerInterface
      * Allow to retrieve every due tasks, the logic used to build the TaskList is own to the scheduler.
      *
      * @throws Throwable {@see TransportInterface::list()}
+     *
+     * @return TaskListInterface<string|int, TaskInterface>
      */
     public function getDueTasks(): TaskListInterface;
 
@@ -63,6 +65,8 @@ interface SchedulerInterface
      * Return every tasks scheduled.
      *
      * @throws Throwable {@see TransportInterface::list()}
+     *
+     * @return TaskListInterface<string|int, TaskInterface>
      */
     public function getTasks(): TaskListInterface;
 

--- a/src/SchedulerInterface.php
+++ b/src/SchedulerInterface.php
@@ -16,7 +16,7 @@ use Throwable;
 interface SchedulerInterface
 {
     /**
-     * Schedule a specific task, the storage of the task is up to the scheduler.
+     * Schedule a specific {@see TaskInterface}, the storage of the task is up to the scheduler.
      */
     public function schedule(TaskInterface $task): void;
 
@@ -50,8 +50,6 @@ interface SchedulerInterface
     /**
      * Allow to retrieve every due tasks, the logic used to build the TaskList is own to the scheduler.
      *
-     * @return TaskListInterface<string, TaskInterface>
-     *
      * @throws Throwable {@see TransportInterface::list()}
      */
     public function getDueTasks(): TaskListInterface;
@@ -63,8 +61,6 @@ interface SchedulerInterface
 
     /**
      * Return every tasks scheduled.
-     *
-     * @return TaskListInterface<string, TaskInterface>
      *
      * @throws Throwable {@see TransportInterface::list()}
      */

--- a/src/Task/NullTask.php
+++ b/src/Task/NullTask.php
@@ -9,6 +9,9 @@ namespace SchedulerBundle\Task;
  */
 final class NullTask extends AbstractTask
 {
+    /**
+     * @param array<string, mixed> $options
+     */
     public function __construct(string $name, array $options = [])
     {
         $this->defineOptions($options);

--- a/src/Task/TaskList.php
+++ b/src/Task/TaskList.php
@@ -122,6 +122,11 @@ final class TaskList implements TaskListInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @param string|null         $offset The name of the task, if null is passed and $value isn't, {@see TaskListInterface::add()} is called
+     * @param TaskInterface|mixed $value A TaskInstance instance or mixed (will trigger an exception)
+     *
+     * @throws Throwable If the $value is not a {@see TaskInterface}
      */
     public function offsetSet($offset, $value): void
     {

--- a/src/Task/TaskList.php
+++ b/src/Task/TaskList.php
@@ -123,7 +123,7 @@ final class TaskList implements TaskListInterface
     /**
      * {@inheritdoc}
      *
-     * @param string|null         $offset The name of the task, if null is passed and $value isn't, {@see TaskListInterface::add()} is called
+     * @param string|null|mixed   $offset The name of the task, if null is passed and $value isn't, {@see TaskListInterface::add()} is called
      * @param TaskInterface|mixed $value A TaskInstance instance or mixed (will trigger an exception)
      *
      * @throws Throwable If the $value is not a {@see TaskInterface}

--- a/src/Task/TaskListInterface.php
+++ b/src/Task/TaskListInterface.php
@@ -16,8 +16,7 @@ use Throwable;
 interface TaskListInterface extends Countable, ArrayAccess, IteratorAggregate
 {
     /**
-     * Add a new task|a set of tasks in the list, by default, the name of the task is used as the key.
-     *
+     * Add a new task|a set of @param TaskInterface ...$task in the list, by default, the name of the task is used as the key.
      *
      * @throws Throwable if a task cannot be added|created in a local or remote transport,
      *                   the task is removed from the list and the exception thrown
@@ -25,25 +24,19 @@ interface TaskListInterface extends Countable, ArrayAccess, IteratorAggregate
     public function add(TaskInterface ...$task): void;
 
     /**
-     * Return if the task exist in the list using its name.
-     *
-     *
+     * Return if the task exist in the list using its @param string $taskName.
      */
     public function has(string $taskName): bool;
 
     /**
-     * Return the desired task if found using its name, otherwise, null.
-     *
-     *
+     * Return the desired {@see TaskInterface} if found using its @param string $taskName, otherwise, null.
      */
     public function get(string $taskName): ?TaskInterface;
 
     /**
-     * Return a new list which contain the desired tasks using the names.
+     * Return a new {@see TaskListInterface} which contain the desired tasks using the names.
      *
      * @param array<int, string> $names
-     *
-     * @return TaskListInterface<string, TaskInterface>
      */
     public function findByName(array $names): self;
 
@@ -55,7 +48,7 @@ interface TaskListInterface extends Countable, ArrayAccess, IteratorAggregate
     public function filter(Closure $filter): self;
 
     /**
-     * Remove the task in the actual list if the name is a valid one.
+     * Remove the task in the actual list if the @param string $taskName is a valid one.
      */
     public function remove(string $taskName): void;
 

--- a/src/Task/TaskListInterface.php
+++ b/src/Task/TaskListInterface.php
@@ -34,7 +34,7 @@ interface TaskListInterface extends Countable, ArrayAccess, IteratorAggregate
     public function get(string $taskName): ?TaskInterface;
 
     /**
-     * Return a new {@see TaskListInterface} which contain the desired tasks using the names.
+     * @return TaskListInterface<string|int, TaskInterface> which contain the desired tasks using the names.
      *
      * @param array<int, string> $names
      */

--- a/src/Transport/ConnectionInterface.php
+++ b/src/Transport/ConnectionInterface.php
@@ -24,8 +24,6 @@ interface ConnectionInterface
      * Return a list containing every tasks stored by the connection.
      *
      * {@internal The task retrieving approach is not described as every connection defines a specific solution}
-     *
-     * @return TaskListInterface<string, TaskInterface>
      */
     public function list(): TaskListInterface;
 

--- a/src/Transport/ConnectionInterface.php
+++ b/src/Transport/ConnectionInterface.php
@@ -21,7 +21,7 @@ interface ConnectionInterface
     public function create(TaskInterface $task): void;
 
     /**
-     * Return a list containing every tasks stored by the connection.
+     * @return TaskListInterface<string|int, TaskInterface> containing every tasks stored by the connection.
      *
      * {@internal The task retrieving approach is not described as every connection defines a specific solution}
      */

--- a/src/Transport/FailOverTransport.php
+++ b/src/Transport/FailOverTransport.php
@@ -119,6 +119,11 @@ final class FailOverTransport extends AbstractTransport
         });
     }
 
+    /**
+     * @param Closure $func
+     *
+     * @return mixed
+     */
     private function execute(Closure $func)
     {
         if ([] === $this->transports) {

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -21,7 +21,7 @@ interface TransportInterface
     public function get(string $name): TaskInterface;
 
     /**
-     * Return all the tasks as a {@see TaskListInterface}, the tasks name are used as keys.
+     * @return TaskListInterface<string|int, TaskInterface>, the tasks name are used as keys.
      *
      * @throws Throwable
      */

--- a/src/Transport/TransportInterface.php
+++ b/src/Transport/TransportInterface.php
@@ -23,8 +23,6 @@ interface TransportInterface
     /**
      * Return all the tasks as a {@see TaskListInterface}, the tasks name are used as keys.
      *
-     * @return TaskListInterface<string, TaskInterface>
-     *
      * @throws Throwable
      */
     public function list(): TaskListInterface;

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -54,6 +54,10 @@ final class Worker implements WorkerInterface
      * @var iterable|RunnerInterface[]
      */
     private iterable $runners;
+
+    /**
+     * @var array<string, bool|int>|null
+     */
     private ?array $options = [];
     private bool $shouldStop = false;
     private SchedulerInterface $scheduler;

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -63,6 +63,10 @@ final class Worker implements WorkerInterface
     private LoggerInterface $logger;
     private LockFactory $lockFactory;
     private ?TaskInterface $lastExecutedTask = null;
+
+    /**
+     * @var TaskListInterface<string|int, TaskInterface>
+     */
     private TaskListInterface $failedTasks;
 
     /**

--- a/src/Worker/WorkerInterface.php
+++ b/src/Worker/WorkerInterface.php
@@ -46,7 +46,7 @@ interface WorkerInterface
     public function isRunning(): bool;
 
     /**
-     * Return a list which contain every task that has fail during execution.
+     * @return TaskListInterface<string|int, TaskInterface> which contain every task that has fail during execution.
      *
      * Every task in this list can also be retrieved independently thanks to {@see TaskFailedEvent}.
      */

--- a/tests/Bridge/Redis/Transport/ConnectionIntegrationTest.php
+++ b/tests/Bridge/Redis/Transport/ConnectionIntegrationTest.php
@@ -281,6 +281,9 @@ final class ConnectionIntegrationTest extends TestCase
         $this->connection->get($task->getName());
     }
 
+    /**
+     * @return Generator<array<int, TaskInterface>>
+     */
     public function provideTasks(): Generator
     {
         yield 'NullTask' => [
@@ -294,6 +297,9 @@ final class ConnectionIntegrationTest extends TestCase
         ];
     }
 
+    /**
+     * @return Generator<array<int, TaskInterface>>
+     */
     public function provideCreateTasks(): Generator
     {
         yield 'NullTask' => [

--- a/tests/Bridge/Redis/Transport/ConnectionTest.php
+++ b/tests/Bridge/Redis/Transport/ConnectionTest.php
@@ -593,6 +593,9 @@ final class ConnectionTest extends TestCase
         $connection->empty();
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideList(): Generator
     {
         yield ['_random'];

--- a/tests/Bridge/Redis/Transport/RedisTransportTest.php
+++ b/tests/Bridge/Redis/Transport/RedisTransportTest.php
@@ -118,6 +118,9 @@ final class RedisTransportTest extends TestCase
         $this->transport->get('foo');
     }
 
+    /**
+     * @return Generator<array<int, ShellTask|NullTask>>
+     */
     public function provideTasks(): Generator
     {
         yield 'NullTask' => [

--- a/tests/Command/ConsumeTasksCommandTest.php
+++ b/tests/Command/ConsumeTasksCommandTest.php
@@ -432,12 +432,18 @@ final class ConsumeTasksCommandTest extends TestCase
         self::assertStringNotContainsString('Task failed: "foo"', $commandTester->getDisplay());
     }
 
+    /**
+     * @return Generator<array<int, int>>
+     */
     public function providerFailureLimitContext(): Generator
     {
         yield 'Multiple tasks' => [10];
         yield 'Single task' => [1];
     }
 
+    /**
+     * @return Generator<array<int, int|string>>
+     */
     public function provideLimitOption(): Generator
     {
         yield [10];

--- a/tests/Command/ExecuteTaskCommandTest.php
+++ b/tests/Command/ExecuteTaskCommandTest.php
@@ -1,0 +1,371 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SchedulerBundle\Command;
+
+use PHPUnit\Framework\TestCase;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use SchedulerBundle\Command\ExecuteTaskCommand;
+use SchedulerBundle\EventListener\StopWorkerOnTaskLimitSubscriber;
+use SchedulerBundle\SchedulerInterface;
+use SchedulerBundle\Task\NullTask;
+use SchedulerBundle\Task\TaskList;
+use SchedulerBundle\Worker\WorkerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Throwable;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class ExecuteTaskCommandTest extends TestCase
+{
+    public function testCommandIsConfigured(): void
+    {
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $scheduler = $this->createMock(SchedulerInterface::class);
+        $worker = $this->createMock(WorkerInterface::class);
+
+        $command = new ExecuteTaskCommand($eventDispatcher, $scheduler, $worker);
+
+        self::assertSame('scheduler:execute', $command->getName());
+        self::assertSame('Execute tasks (due or not) depending on filters', $command->getDescription());
+        self::assertTrue($command->getDefinition()->hasOption('due'));
+        self::assertSame('d', $command->getDefinition()->getOption('due')->getShortcut());
+        self::assertFalse($command->getDefinition()->getOption('due')->acceptValue());
+        self::assertSame('Define if the filters must be applied on due tasks', $command->getDefinition()->getOption('due')->getDescription());
+        self::assertTrue($command->getDefinition()->hasOption('name'));
+        self::assertSame('n', $command->getDefinition()->getOption('name')->getShortcut());
+        self::assertTrue($command->getDefinition()->getOption('name')->isValueOptional());
+        self::assertTrue($command->getDefinition()->getOption('name')->isArray());
+        self::assertSame('The name of the task(s) to execute', $command->getDefinition()->getOption('name')->getDescription());
+        self::assertTrue($command->getDefinition()->hasOption('expression'));
+        self::assertNull($command->getDefinition()->getOption('expression')->getShortcut());
+        self::assertTrue($command->getDefinition()->getOption('expression')->isValueOptional());
+        self::assertTrue($command->getDefinition()->getOption('expression')->isArray());
+        self::assertSame('The expression of the task(s) to execute', $command->getDefinition()->getOption('expression')->getDescription());
+        self::assertTrue($command->getDefinition()->hasOption('tags'));
+        self::assertSame('t', $command->getDefinition()->getOption('tags')->getShortcut());
+        self::assertTrue($command->getDefinition()->getOption('tags')->isValueOptional());
+        self::assertTrue($command->getDefinition()->getOption('tags')->isArray());
+        self::assertSame('The tags of the task(s) to execute', $command->getDefinition()->getOption('tags')->getDescription());
+        self::assertSame(
+        $command->getHelp(),
+        <<<'EOF'
+            The <info>%command.name%</info> command execute tasks.
+
+                <info>php %command.full_name%</info>
+
+            Use the --due option to execute the due tasks:
+                <info>php %command.full_name% --due</info>
+
+            Use the --name option to filter the executed tasks depending on their name:
+                <info>php %command.full_name% --name=foo, bar</info>
+
+            Use the --expression option to filter the executed tasks depending on their expression:
+                <info>php %command.full_name% --expression=* * * * *</info>
+
+            Use the --tags option to filter the executed tasks depending on their tags:
+                <info>php %command.full_name% --tags=foo, bar</info>
+            EOF
+        );
+    }
+
+    public function testCommandCannotExecuteDueTasks(): void
+    {
+        $worker = $this->createMock(WorkerInterface::class);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects(self::never())->method('dispatch');
+
+        $scheduler = $this->createMock(SchedulerInterface::class);
+        $scheduler->expects(self::once())->method('getDueTasks')->willReturn(new TaskList());
+
+        $command = new ExecuteTaskCommand($eventDispatcher, $scheduler, $worker);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '--due' => true,
+        ]);
+
+        self::assertStringContainsString('[WARNING] No tasks to execute found', $tester->getDisplay());
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    public function testCommandCannotExecuteWholeTasksList(): void
+    {
+        $worker = $this->createMock(WorkerInterface::class);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects(self::never())->method('dispatch');
+
+        $scheduler = $this->createMock(SchedulerInterface::class);
+        $scheduler->expects(self::once())->method('getTasks')->willReturn(new TaskList());
+        $scheduler->expects(self::never())->method('getDueTasks');
+
+        $command = new ExecuteTaskCommand($eventDispatcher, $scheduler, $worker);
+        $tester = new CommandTester($command);
+        $tester->execute([]);
+
+        self::assertStringContainsString('[WARNING] No tasks to execute found', $tester->getDisplay());
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testCommandCanExecuteDueTasksWithSpecificName(): void
+    {
+        $task = new NullTask('foo');
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects(self::once())->method('dispatch')->with(new StopWorkerOnTaskLimitSubscriber(1, $logger));
+
+        $worker = $this->createMock(WorkerInterface::class);
+        $worker->expects(self::once())->method('execute')->with(self::equalTo([]), self::equalTo($task));
+
+        $scheduler = $this->createMock(SchedulerInterface::class);
+        $scheduler->expects(self::once())->method('getDueTasks')->willReturn(new TaskList([$task]));
+
+        $command = new ExecuteTaskCommand($eventDispatcher, $scheduler, $worker, $logger);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '--due' => true,
+            '--name' => ['foo'],
+        ]);
+
+        self::assertStringContainsString('[INFO] Found 1 task', $tester->getDisplay());
+        self::assertStringNotContainsString('[WARNING] No tasks to execute found', $tester->getDisplay());
+        self::assertStringContainsString('[INFO] The tasks following the listed conditions will be executed:', $tester->getDisplay());
+        self::assertStringContainsString('- Task(s) with the following name(s): foo', $tester->getDisplay());
+        self::assertStringContainsString('1 task to be executed', $tester->getDisplay());
+        self::assertStringContainsString('[OK] 1 task has been executed', $tester->getDisplay());
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testCommandCanExecuteMultipleDueTasksWithSpecificName(): void
+    {
+        $task = new NullTask('foo');
+        $secondTask = new NullTask('bar');
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects(self::once())->method('dispatch')->with(new StopWorkerOnTaskLimitSubscriber(2, $logger));
+
+        $worker = $this->createMock(WorkerInterface::class);
+        $worker->expects(self::once())->method('execute')->with(self::equalTo([]), self::equalTo($task), self::equalTo($secondTask));
+
+        $scheduler = $this->createMock(SchedulerInterface::class);
+        $scheduler->expects(self::once())->method('getDueTasks')->willReturn(new TaskList([$task, $secondTask]));
+
+        $command = new ExecuteTaskCommand($eventDispatcher, $scheduler, $worker, $logger);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '--due' => true,
+            '--name' => ['foo', 'bar'],
+        ]);
+
+        self::assertStringContainsString('[INFO] Found 2 tasks', $tester->getDisplay());
+        self::assertStringNotContainsString('[WARNING] No tasks to execute found', $tester->getDisplay());
+        self::assertStringContainsString('[INFO] The tasks following the listed conditions will be executed:', $tester->getDisplay());
+        self::assertStringContainsString('- Task(s) with the following name(s): foo', $tester->getDisplay());
+        self::assertStringContainsString('2 tasks to be executed', $tester->getDisplay());
+        self::assertStringContainsString('[OK] 2 tasks have been executed', $tester->getDisplay());
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testCommandCanExecuteWholeTasksListWithSpecificName(): void
+    {
+        $task = new NullTask('foo');
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects(self::once())->method('dispatch')->with(new StopWorkerOnTaskLimitSubscriber(1, $logger));
+
+        $worker = $this->createMock(WorkerInterface::class);
+        $worker->expects(self::once())->method('execute')->with(self::equalTo([]), self::equalTo($task));
+
+        $scheduler = $this->createMock(SchedulerInterface::class);
+        $scheduler->expects(self::never())->method('getDueTasks');
+        $scheduler->expects(self::once())->method('getTasks')->willReturn(new TaskList([$task]));
+
+        $command = new ExecuteTaskCommand($eventDispatcher, $scheduler, $worker, $logger);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '--name' => ['foo'],
+        ]);
+
+        self::assertStringContainsString('[INFO] Found 1 task', $tester->getDisplay());
+        self::assertStringNotContainsString('[WARNING] No tasks to execute found', $tester->getDisplay());
+        self::assertStringContainsString('[INFO] The tasks following the listed conditions will be executed:', $tester->getDisplay());
+        self::assertStringContainsString('- Task(s) with the following name(s): foo', $tester->getDisplay());
+        self::assertStringContainsString('1 task to be executed', $tester->getDisplay());
+        self::assertStringContainsString('[OK] 1 task has been executed', $tester->getDisplay());
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testCommandCanExecuteWholeTasksListWithMultipleTasksWithSpecificName(): void
+    {
+        $task = new NullTask('foo');
+        $secondTask = new NullTask('bar');
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects(self::once())->method('dispatch')->with(new StopWorkerOnTaskLimitSubscriber(2, $logger));
+
+        $worker = $this->createMock(WorkerInterface::class);
+        $worker->expects(self::once())->method('execute')->with(self::equalTo([]), self::equalTo($task), self::equalTo($secondTask));
+
+        $scheduler = $this->createMock(SchedulerInterface::class);
+        $scheduler->expects(self::never())->method('getDueTasks');
+        $scheduler->expects(self::once())->method('getTasks')->willReturn(new TaskList([$task, $secondTask]));
+
+        $command = new ExecuteTaskCommand($eventDispatcher, $scheduler, $worker, $logger);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '--name' => ['foo', 'bar'],
+        ]);
+
+        self::assertStringContainsString('[INFO] Found 2 tasks', $tester->getDisplay());
+        self::assertStringNotContainsString('[WARNING] No tasks to execute found', $tester->getDisplay());
+        self::assertStringContainsString('[INFO] The tasks following the listed conditions will be executed:', $tester->getDisplay());
+        self::assertStringContainsString('- Task(s) with the following name(s): foo', $tester->getDisplay());
+        self::assertStringContainsString('2 tasks to be executed', $tester->getDisplay());
+        self::assertStringContainsString('[OK] 2 tasks have been executed', $tester->getDisplay());
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testCommandCanExecuteDueTasksWithSpecificExpression(): void
+    {
+        $task = new NullTask('foo');
+        $logger = $this->createMock(LoggerInterface::class);
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->expects(self::once())->method('dispatch')->with(new StopWorkerOnTaskLimitSubscriber(1, $logger));
+
+        $worker = $this->createMock(WorkerInterface::class);
+        $worker->expects(self::once())->method('execute')->with(self::equalTo([]), self::equalTo($task));
+
+        $scheduler = $this->createMock(SchedulerInterface::class);
+        $scheduler->expects(self::once())->method('getDueTasks')->willReturn(new TaskList([$task]));
+
+        $command = new ExecuteTaskCommand($eventDispatcher, $scheduler, $worker, $logger);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '--due' => true,
+            '--expression' => ['* * * * *'],
+        ]);
+
+        self::assertStringContainsString('[INFO] Found 1 task', $tester->getDisplay());
+        self::assertStringNotContainsString('[WARNING] No tasks to execute found', $tester->getDisplay());
+        self::assertStringContainsString('[INFO] The tasks following the listed conditions will be executed:', $tester->getDisplay());
+        self::assertStringContainsString('- Task(s) with the following expression(s): * * * * *', $tester->getDisplay());
+        self::assertStringContainsString('1 task to be executed', $tester->getDisplay());
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testCommandCanExecuteWholeTasksListWithSpecificExpression(): void
+    {
+        $task = new NullTask('foo');
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $worker = $this->createMock(WorkerInterface::class);
+        $worker->expects(self::once())->method('execute')->with(self::equalTo([]), self::equalTo($task));
+
+        $scheduler = $this->createMock(SchedulerInterface::class);
+        $scheduler->expects(self::never())->method('getDueTasks');
+        $scheduler->expects(self::once())->method('getTasks')->willReturn(new TaskList([$task]));
+
+        $command = new ExecuteTaskCommand($eventDispatcher, $scheduler, $worker);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '--expression' => ['* * * * *'],
+        ]);
+
+        self::assertStringContainsString('[INFO] Found 1 task', $tester->getDisplay());
+        self::assertStringNotContainsString('[WARNING] No tasks to execute found', $tester->getDisplay());
+        self::assertStringContainsString('[INFO] The tasks following the listed conditions will be executed:', $tester->getDisplay());
+        self::assertStringContainsString('- Task(s) with the following expression(s): * * * * *', $tester->getDisplay());
+        self::assertStringContainsString('1 task to be executed', $tester->getDisplay());
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testCommandCanExecuteDueTasksWithSpecificTags(): void
+    {
+        $task = new NullTask('foo', [
+            'tags' => ['@reboot', '@deploy'],
+        ]);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $worker = $this->createMock(WorkerInterface::class);
+        $worker->expects(self::once())->method('execute')->with(self::equalTo([]), self::equalTo($task));
+
+        $scheduler = $this->createMock(SchedulerInterface::class);
+        $scheduler->expects(self::once())->method('getDueTasks')->willReturn(new TaskList([$task]));
+
+        $command = new ExecuteTaskCommand($eventDispatcher, $scheduler, $worker);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '--due' => true,
+            '--tags' => ['@reboot', '@deploy'],
+        ]);
+
+        self::assertStringContainsString('[INFO] Found 1 task', $tester->getDisplay());
+        self::assertStringNotContainsString('[WARNING] No tasks to execute found', $tester->getDisplay());
+        self::assertStringContainsString('[INFO] The tasks following the listed conditions will be executed:', $tester->getDisplay());
+        self::assertStringContainsString('- Task(s) with the following tags(s): @reboot, @deploy', $tester->getDisplay());
+        self::assertStringContainsString('1 task to be executed', $tester->getDisplay());
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testCommandCanExecuteWholeTasksListWithSpecificTags(): void
+    {
+        $task = new NullTask('foo', [
+            'tags' => ['@reboot', '@deploy'],
+        ]);
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $worker = $this->createMock(WorkerInterface::class);
+        $worker->expects(self::once())->method('execute')->with(self::equalTo([]), self::equalTo($task));
+
+        $scheduler = $this->createMock(SchedulerInterface::class);
+        $scheduler->expects(self::never())->method('getDueTasks');
+        $scheduler->expects(self::once())->method('getTasks')->willReturn(new TaskList([$task]));
+
+        $command = new ExecuteTaskCommand($eventDispatcher, $scheduler, $worker);
+        $tester = new CommandTester($command);
+        $tester->execute([
+            '--tags' => ['@reboot', '@deploy'],
+        ]);
+
+        self::assertStringContainsString('[INFO] Found 1 task', $tester->getDisplay());
+        self::assertStringNotContainsString('[WARNING] No tasks to execute found', $tester->getDisplay());
+        self::assertStringContainsString('[INFO] The tasks following the listed conditions will be executed:', $tester->getDisplay());
+        self::assertStringContainsString('- Task(s) with the following tags(s): @reboot, @deploy', $tester->getDisplay());
+        self::assertStringContainsString('1 task to be executed', $tester->getDisplay());
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode());
+    }
+}

--- a/tests/Command/ExecuteTaskCommandTest.php
+++ b/tests/Command/ExecuteTaskCommandTest.php
@@ -275,6 +275,7 @@ final class ExecuteTaskCommandTest extends TestCase
         self::assertStringContainsString('[INFO] The tasks following the listed conditions will be executed:', $tester->getDisplay());
         self::assertStringContainsString('- Task(s) with the following expression(s): * * * * *', $tester->getDisplay());
         self::assertStringContainsString('1 task to be executed', $tester->getDisplay());
+        self::assertStringContainsString('1 task has been executed', $tester->getDisplay());
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
     }
 
@@ -304,6 +305,7 @@ final class ExecuteTaskCommandTest extends TestCase
         self::assertStringContainsString('[INFO] The tasks following the listed conditions will be executed:', $tester->getDisplay());
         self::assertStringContainsString('- Task(s) with the following expression(s): * * * * *', $tester->getDisplay());
         self::assertStringContainsString('1 task to be executed', $tester->getDisplay());
+        self::assertStringContainsString('1 task has been executed', $tester->getDisplay());
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
     }
 
@@ -335,6 +337,7 @@ final class ExecuteTaskCommandTest extends TestCase
         self::assertStringContainsString('[INFO] The tasks following the listed conditions will be executed:', $tester->getDisplay());
         self::assertStringContainsString('- Task(s) with the following tags(s): @reboot, @deploy', $tester->getDisplay());
         self::assertStringContainsString('1 task to be executed', $tester->getDisplay());
+        self::assertStringContainsString('1 task has been executed', $tester->getDisplay());
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
     }
 
@@ -366,6 +369,7 @@ final class ExecuteTaskCommandTest extends TestCase
         self::assertStringContainsString('[INFO] The tasks following the listed conditions will be executed:', $tester->getDisplay());
         self::assertStringContainsString('- Task(s) with the following tags(s): @reboot, @deploy', $tester->getDisplay());
         self::assertStringContainsString('1 task to be executed', $tester->getDisplay());
+        self::assertStringContainsString('1 task has been executed', $tester->getDisplay());
         self::assertSame(Command::SUCCESS, $tester->getStatusCode());
     }
 }

--- a/tests/Command/ExecuteTaskCommandTest.php
+++ b/tests/Command/ExecuteTaskCommandTest.php
@@ -52,24 +52,24 @@ final class ExecuteTaskCommandTest extends TestCase
         self::assertTrue($command->getDefinition()->getOption('tags')->isArray());
         self::assertSame('The tags of the task(s) to execute', $command->getDefinition()->getOption('tags')->getDescription());
         self::assertSame(
-        $command->getHelp(),
-        <<<'EOF'
-            The <info>%command.name%</info> command execute tasks.
+            $command->getHelp(),
+            <<<'EOF'
+                The <info>%command.name%</info> command execute tasks.
 
-                <info>php %command.full_name%</info>
+                    <info>php %command.full_name%</info>
 
-            Use the --due option to execute the due tasks:
-                <info>php %command.full_name% --due</info>
+                Use the --due option to execute the due tasks:
+                    <info>php %command.full_name% --due</info>
 
-            Use the --name option to filter the executed tasks depending on their name:
-                <info>php %command.full_name% --name=foo, bar</info>
+                Use the --name option to filter the executed tasks depending on their name:
+                    <info>php %command.full_name% --name=foo, bar</info>
 
-            Use the --expression option to filter the executed tasks depending on their expression:
-                <info>php %command.full_name% --expression=* * * * *</info>
+                Use the --expression option to filter the executed tasks depending on their expression:
+                    <info>php %command.full_name% --expression=* * * * *</info>
 
-            Use the --tags option to filter the executed tasks depending on their tags:
-                <info>php %command.full_name% --tags=foo, bar</info>
-            EOF
+                Use the --tags option to filter the executed tasks depending on their tags:
+                    <info>php %command.full_name% --tags=foo, bar</info>
+                EOF
         );
     }
 

--- a/tests/Command/ListTasksCommandTest.php
+++ b/tests/Command/ListTasksCommandTest.php
@@ -310,12 +310,18 @@ final class ListTasksCommandTest extends TestCase
         self::assertStringContainsString('[WARNING] No tasks found', $commandTester->getDisplay());
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideStateOption(): Generator
     {
         yield ['--state'];
         yield ['-s'];
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideOptions(): Generator
     {
         yield ['--expression', '--state'];

--- a/tests/DependencyInjection/SchedulerBundleExtensionTest.php
+++ b/tests/DependencyInjection/SchedulerBundleExtensionTest.php
@@ -363,12 +363,16 @@ final class SchedulerBundleExtensionTest extends TestCase
         self::assertCount(4, $container->getDefinition(ExecuteTaskCommand::class)->getArguments());
         self::assertInstanceOf(Reference::class, $container->getDefinition(ExecuteTaskCommand::class)->getArgument(0));
         self::assertSame(EventDispatcherInterface::class, (string) $container->getDefinition(ExecuteTaskCommand::class)->getArgument(0));
+        self::assertSame(ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $container->getDefinition(ExecuteTaskCommand::class)->getArgument(0)->getInvalidBehavior());
         self::assertInstanceOf(Reference::class, $container->getDefinition(ExecuteTaskCommand::class)->getArgument(1));
         self::assertSame(SchedulerInterface::class, (string) $container->getDefinition(ExecuteTaskCommand::class)->getArgument(1));
+        self::assertSame(ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $container->getDefinition(ExecuteTaskCommand::class)->getArgument(1)->getInvalidBehavior());
         self::assertInstanceOf(Reference::class, $container->getDefinition(ExecuteTaskCommand::class)->getArgument(2));
         self::assertSame(WorkerInterface::class, (string) $container->getDefinition(ExecuteTaskCommand::class)->getArgument(2));
+        self::assertSame(ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $container->getDefinition(ExecuteTaskCommand::class)->getArgument(2)->getInvalidBehavior());
         self::assertInstanceOf(Reference::class, $container->getDefinition(ExecuteTaskCommand::class)->getArgument(3));
         self::assertSame(LoggerInterface::class, (string) $container->getDefinition(ExecuteTaskCommand::class)->getArgument(3));
+        self::assertSame(ContainerInterface::NULL_ON_INVALID_REFERENCE, $container->getDefinition(ExecuteTaskCommand::class)->getArgument(3)->getInvalidBehavior());
         self::assertTrue($container->getDefinition(ExecuteTaskCommand::class)->hasTag('console.command'));
         self::assertTrue($container->getDefinition(ExecuteTaskCommand::class)->hasTag('monolog.logger'));
         self::assertSame('scheduler', $container->getDefinition(ExecuteTaskCommand::class)->getTag('monolog.logger')[0]['channel']);

--- a/tests/DependencyInjection/SchedulerBundleExtensionTest.php
+++ b/tests/DependencyInjection/SchedulerBundleExtensionTest.php
@@ -1131,6 +1131,9 @@ final class SchedulerBundleExtensionTest extends TestCase
         self::assertInstanceOf(SchedulerBundleConfiguration::class, $extension->getConfiguration([], new ContainerBuilder()));
     }
 
+    /**
+     * @param array<string, mixed> $configuration
+     */
     private function getContainer(array $configuration = []): ContainerBuilder
     {
         $containerBuilder = new ContainerBuilder();

--- a/tests/DependencyInjection/SchedulerBundleExtensionTest.php
+++ b/tests/DependencyInjection/SchedulerBundleExtensionTest.php
@@ -11,6 +11,7 @@ use SchedulerBundle\Bridge\Doctrine\SchemaListener\SchedulerTransportDoctrineSch
 use SchedulerBundle\Bridge\Doctrine\Transport\DoctrineTransportFactory;
 use SchedulerBundle\Bridge\Redis\Transport\RedisTransportFactory;
 use SchedulerBundle\Command\ConsumeTasksCommand;
+use SchedulerBundle\Command\ExecuteTaskCommand;
 use SchedulerBundle\Command\ListFailedTasksCommand;
 use SchedulerBundle\Command\ListTasksCommand;
 use SchedulerBundle\Command\RebootSchedulerCommand;
@@ -357,6 +358,22 @@ final class SchedulerBundleExtensionTest extends TestCase
         self::assertSame('scheduler', $container->getDefinition(ConsumeTasksCommand::class)->getTag('monolog.logger')[0]['channel']);
         self::assertTrue($container->getDefinition(ConsumeTasksCommand::class)->hasTag('container.preload'));
         self::assertSame(ConsumeTasksCommand::class, $container->getDefinition(ConsumeTasksCommand::class)->getTag('container.preload')[0]['class']);
+
+        self::assertTrue($container->hasDefinition(ExecuteTaskCommand::class));
+        self::assertCount(4, $container->getDefinition(ExecuteTaskCommand::class)->getArguments());
+        self::assertInstanceOf(Reference::class, $container->getDefinition(ExecuteTaskCommand::class)->getArgument(0));
+        self::assertSame(EventDispatcherInterface::class, (string) $container->getDefinition(ExecuteTaskCommand::class)->getArgument(0));
+        self::assertInstanceOf(Reference::class, $container->getDefinition(ExecuteTaskCommand::class)->getArgument(1));
+        self::assertSame(SchedulerInterface::class, (string) $container->getDefinition(ExecuteTaskCommand::class)->getArgument(1));
+        self::assertInstanceOf(Reference::class, $container->getDefinition(ExecuteTaskCommand::class)->getArgument(2));
+        self::assertSame(WorkerInterface::class, (string) $container->getDefinition(ExecuteTaskCommand::class)->getArgument(2));
+        self::assertInstanceOf(Reference::class, $container->getDefinition(ExecuteTaskCommand::class)->getArgument(3));
+        self::assertSame(LoggerInterface::class, (string) $container->getDefinition(ExecuteTaskCommand::class)->getArgument(3));
+        self::assertTrue($container->getDefinition(ExecuteTaskCommand::class)->hasTag('console.command'));
+        self::assertTrue($container->getDefinition(ExecuteTaskCommand::class)->hasTag('monolog.logger'));
+        self::assertSame('scheduler', $container->getDefinition(ExecuteTaskCommand::class)->getTag('monolog.logger')[0]['channel']);
+        self::assertTrue($container->getDefinition(ExecuteTaskCommand::class)->hasTag('container.preload'));
+        self::assertSame(ExecuteTaskCommand::class, $container->getDefinition(ExecuteTaskCommand::class)->getTag('container.preload')[0]['class']);
 
         self::assertTrue($container->hasDefinition(ListFailedTasksCommand::class));
         self::assertCount(1, $container->getDefinition(ListFailedTasksCommand::class)->getArguments());

--- a/tests/EventListener/StopWorkerOnTimeLimitSubscriberTest.php
+++ b/tests/EventListener/StopWorkerOnTimeLimitSubscriberTest.php
@@ -80,6 +80,9 @@ final class StopWorkerOnTimeLimitSubscriberTest extends TestCase
         $stopWorkerOnTimeLimitSubscriber->onWorkerRunning($workerRunningEvent);
     }
 
+    /**
+     * @return Generator<array<int, int>>
+     */
     public function provideTimeLimit(): Generator
     {
         yield [1];

--- a/tests/Expression/ComputedExpressionBuilderTest.php
+++ b/tests/Expression/ComputedExpressionBuilderTest.php
@@ -33,6 +33,9 @@ final class ComputedExpressionBuilderTest extends TestCase
         self::assertNotSame($finalExpression->getExpression(), $expression);
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideExpression(): Generator
     {
         yield ['# * * * *'];

--- a/tests/Expression/FluentExpressionBuilderTest.php
+++ b/tests/Expression/FluentExpressionBuilderTest.php
@@ -45,6 +45,9 @@ final class FluentExpressionBuilderTest extends TestCase
         self::assertSame($finalExpression->getExpression(), $endExpression);
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideExpression(): Generator
     {
         yield ['first monday of January 1980 10:00', '0 10 7 1 1'];
@@ -54,6 +57,9 @@ final class FluentExpressionBuilderTest extends TestCase
         yield ['10/Oct/2000:13:55:36 -0700', '55 20 10 10 2'];
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideExpressionWithTimezone(): Generator
     {
         yield ['first monday of January 1980 10:00', '0 10 7 1 1', 'UTC'];

--- a/tests/SchedulerTest.php
+++ b/tests/SchedulerTest.php
@@ -750,6 +750,9 @@ final class SchedulerTest extends TestCase
         $scheduler->yieldTask('foo', true);
     }
 
+    /**
+     * @return Generator<array<int, ShellTask>>
+     */
     public function provideTasks(): Generator
     {
         yield 'Shell tasks' => [

--- a/tests/Task/Builder/ChainedBuilderTest.php
+++ b/tests/Task/Builder/ChainedBuilderTest.php
@@ -36,6 +36,8 @@ final class ChainedBuilderTest extends TestCase
 
     /**
      * @dataProvider provideTaskData
+     *
+     * @param array<string, mixed> $configuration
      */
     public function testBuilderCanBuildWithoutBuilders(array $configuration): void
     {
@@ -53,6 +55,8 @@ final class ChainedBuilderTest extends TestCase
 
     /**
      * @dataProvider provideTaskData
+     *
+     * @param array<string, mixed> $configuration
      */
     public function testBuilderCanBuild(array $configuration): void
     {
@@ -75,6 +79,9 @@ final class ChainedBuilderTest extends TestCase
         self::assertInstanceOf(ShellTask::class, $task->getTask(0));
     }
 
+    /**
+     * @return Generator<array<int, array<string, mixed>>>
+     */
     public function provideTaskData(): Generator
     {
         yield [

--- a/tests/Task/Builder/CommandBuilderTest.php
+++ b/tests/Task/Builder/CommandBuilderTest.php
@@ -34,6 +34,8 @@ final class CommandBuilderTest extends TestCase
 
     /**
      * @dataProvider provideTaskData
+     *
+     * @param array<string, mixed> $options
      */
     public function testTaskCanBeBuilt(array $options): void
     {
@@ -57,6 +59,9 @@ final class CommandBuilderTest extends TestCase
         self::assertSame(TaskInterface::ENABLED, $task->getState());
     }
 
+    /**
+     * @return Generator<array<int, array<string, mixed>>>
+     */
     public function provideTaskData(): Generator
     {
         yield [

--- a/tests/Task/Builder/HttpBuilderTest.php
+++ b/tests/Task/Builder/HttpBuilderTest.php
@@ -34,6 +34,8 @@ final class HttpBuilderTest extends TestCase
 
     /**
      * @dataProvider provideTaskData
+     *
+     * @param array<string, mixed> $options
      */
     public function testTaskCanBeBuilt(array $options): void
     {
@@ -57,6 +59,9 @@ final class HttpBuilderTest extends TestCase
         self::assertSame(TaskInterface::ENABLED, $task->getState());
     }
 
+    /**
+     * @return Generator<array<int, array<string, mixed>>>
+     */
     public function provideTaskData(): Generator
     {
         yield [

--- a/tests/Task/Builder/NullBuilderTest.php
+++ b/tests/Task/Builder/NullBuilderTest.php
@@ -34,6 +34,8 @@ final class NullBuilderTest extends TestCase
 
     /**
      * @dataProvider provideTaskData
+     *
+     * @param array<string, mixed> $options
      */
     public function testTaskCanBeBuilt(array $options): void
     {
@@ -55,6 +57,9 @@ final class NullBuilderTest extends TestCase
         self::assertSame(TaskInterface::ENABLED, $task->getState());
     }
 
+    /**
+     * @return Generator<array<int, array<string, mixed>>>
+     */
     public function provideTaskData(): Generator
     {
         yield [

--- a/tests/Task/Builder/ShellBuilderTest.php
+++ b/tests/Task/Builder/ShellBuilderTest.php
@@ -34,6 +34,8 @@ final class ShellBuilderTest extends TestCase
 
     /**
      * @dataProvider provideTaskData
+     *
+     * @param array<string, mixed> $options
      */
     public function testTaskCanBeBuilt(array $options): void
     {

--- a/tests/Task/Builder/ShellBuilderTest.php
+++ b/tests/Task/Builder/ShellBuilderTest.php
@@ -68,6 +68,9 @@ final class ShellBuilderTest extends TestCase
         self::assertEmpty($task->getEnvironmentVariables());
     }
 
+    /**
+     * @return Generator<array<int, array<string, mixed>>>
+     */
     public function provideTaskData(): Generator
     {
         yield [

--- a/tests/Task/NullTaskTest.php
+++ b/tests/Task/NullTaskTest.php
@@ -580,6 +580,9 @@ final class NullTaskTest extends TestCase
         self::assertNull($nullTask->getAfterExecutingNotificationBag());
     }
 
+    /**
+     * @return Generator<array<int, int>>
+     */
     public function provideNice(): Generator
     {
         yield [20];

--- a/tests/Task/TaskBuilderTest.php
+++ b/tests/Task/TaskBuilderTest.php
@@ -48,6 +48,8 @@ final class TaskBuilderTest extends TestCase
 
     /**
      * @dataProvider provideNullTaskData
+     *
+     * @param array<string, mixed> $options
      */
     public function testBuilderCanCreateNullTask(array $options): void
     {
@@ -68,6 +70,8 @@ final class TaskBuilderTest extends TestCase
 
     /**
      * @dataProvider provideShellTaskData
+     *
+     * @param array<string, mixed> $options
      */
     public function testBuilderCanCreateShellTask(array $options): void
     {
@@ -88,6 +92,8 @@ final class TaskBuilderTest extends TestCase
 
     /**
      * @dataProvider provideCommandTaskData
+     *
+     * @param array<string, mixed> $options
      */
     public function testBuilderCanCreateCommandTask(array $options): void
     {
@@ -108,6 +114,8 @@ final class TaskBuilderTest extends TestCase
 
     /**
      * @dataProvider provideHttpTaskData
+     *
+     * @param array<string, mixed> $options
      */
     public function testBuilderCanCreateHttpTask(array $options): void
     {

--- a/tests/Task/TaskBuilderTest.php
+++ b/tests/Task/TaskBuilderTest.php
@@ -126,6 +126,9 @@ final class TaskBuilderTest extends TestCase
         self::assertInstanceOf(HttpTask::class, $taskBuilder->create($options));
     }
 
+    /**
+     * @return Generator<array<int, array<string, mixed>>>
+     */
     public function provideNullTaskData(): Generator
     {
         yield [
@@ -156,6 +159,9 @@ final class TaskBuilderTest extends TestCase
         ];
     }
 
+    /**
+     * @return Generator<array<int, array<string, mixed>>>
+     */
     public function provideShellTaskData(): Generator
     {
         yield [
@@ -186,6 +192,9 @@ final class TaskBuilderTest extends TestCase
         ];
     }
 
+    /**
+     * @return Generator<array<int, array<string, mixed>>>
+     */
     public function provideCommandTaskData(): Generator
     {
         yield [
@@ -214,6 +223,9 @@ final class TaskBuilderTest extends TestCase
         ];
     }
 
+    /**
+     * @return Generator<array<int, array<string, mixed>>>
+     */
     public function provideHttpTaskData(): Generator
     {
         yield [

--- a/tests/Task/TaskExecutionTrackerTest.php
+++ b/tests/Task/TaskExecutionTrackerTest.php
@@ -46,6 +46,9 @@ final class TaskExecutionTrackerTest extends TestCase
         self::assertNotNull($task->getExecutionMemoryUsage());
     }
 
+    /**
+     * @return Generator<array<int, TaskInterface>>
+     */
     public function provideTrackedTasks(): Generator
     {
         yield [
@@ -54,6 +57,9 @@ final class TaskExecutionTrackerTest extends TestCase
         ];
     }
 
+    /**
+     * @return Generator<array<int, TaskInterface>>
+     */
     public function provideUnTrackedTasks(): Generator
     {
         yield [

--- a/tests/Transport/DsnTest.php
+++ b/tests/Transport/DsnTest.php
@@ -30,6 +30,9 @@ final class DsnTest extends TestCase
         self::assertEquals($dsn, Dsn::fromString($input));
     }
 
+    /**
+     * @return Generator<array<int, Dsn|string>>
+     */
     public function provideDsn(): Generator
     {
         yield 'Redis transport DSN' => [

--- a/tests/Transport/FailOverTransportFactoryTest.php
+++ b/tests/Transport/FailOverTransportFactoryTest.php
@@ -80,12 +80,18 @@ final class FailOverTransportFactoryTest extends TestCase
         self::assertSame('normal', $transport->getOptions()['mode']);
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideDsn(): Generator
     {
         yield ['failover://(memory://first_in_first_out || memory://last_in_first_out)'];
         yield ['fo://(memory://first_in_first_out || memory://last_in_first_out)'];
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideDsnWithOptions(): Generator
     {
         yield ['failover://(memory://first_in_first_out || memory://last_in_first_out)?mode=normal'];

--- a/tests/Transport/InMemoryTransportFactoryTest.php
+++ b/tests/Transport/InMemoryTransportFactoryTest.php
@@ -60,6 +60,9 @@ final class InMemoryTransportFactoryTest extends TestCase
         self::assertCount(2, $transport->getOptions());
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideDsn(): Generator
     {
         yield 'simple configuration' => [
@@ -70,6 +73,9 @@ final class InMemoryTransportFactoryTest extends TestCase
         ];
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideAdvancedDsn(): Generator
     {
         yield 'advanced configuration' => [

--- a/tests/Transport/InMemoryTransportTest.php
+++ b/tests/Transport/InMemoryTransportTest.php
@@ -277,6 +277,9 @@ final class InMemoryTransportTest extends TestCase
         self::assertCount(0, $inMemoryTransport->list());
     }
 
+    /**
+     * @return Generator<array<int, TaskInterface>>
+     */
     public function provideTasks(): Generator
     {
         yield [

--- a/tests/Transport/LongTailTransportFactoryTest.php
+++ b/tests/Transport/LongTailTransportFactoryTest.php
@@ -42,6 +42,9 @@ final class LongTailTransportFactoryTest extends TestCase
         self::assertInstanceOf(LongTailTransport::class, $transport);
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideDsn(): Generator
     {
         yield ['longtail://(memory://first_in_first_out || memory://last_in_first_out)'];

--- a/tests/Transport/RoundRobinTransportFactoryTest.php
+++ b/tests/Transport/RoundRobinTransportFactoryTest.php
@@ -46,6 +46,9 @@ final class RoundRobinTransportFactoryTest extends TestCase
         self::assertSame(2, $transport->getOptions()['quantum']);
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideDsn(): Generator
     {
         yield ['roundrobin://(memory://first_in_first_out && memory://last_in_first_out)'];

--- a/tests/Transport/TransportFactoryTest.php
+++ b/tests/Transport/TransportFactoryTest.php
@@ -122,29 +122,44 @@ final class TransportFactoryTest extends TestCase
         $transportFactory->createTransport('foo://', [], $serializer, new SchedulePolicyOrchestrator([]));
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideFilesystemDsn(): Generator
     {
         yield 'Full' => ['filesystem://first_in_first_out'];
         yield 'Short' => ['fs://first_in_first_out'];
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideMemoryDsn(): Generator
     {
         yield 'Full' => ['memory://first_in_first_out'];
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideFailoverDsn(): Generator
     {
         yield 'Full' => ['failover://(fs://first_in_first_out || memory://first_in_first_out)'];
         yield 'Short' => ['fo://(fs://first_in_first_out || memory://first_in_first_out)'];
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideRoundRobinDsn(): Generator
     {
         yield 'Full' => ['roundrobin://(fs://first_in_first_out || memory://first_in_first_out)'];
         yield 'Short' => ['rr://(fs://first_in_first_out || memory://first_in_first_out)'];
     }
 
+    /**
+     * @return Generator<array<int, string>>
+     */
     public function provideLongTailDsn(): Generator
     {
         yield 'Full' => ['longtail://(fs://first_in_first_out <> memory://first_in_first_out)'];


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | 7.4
| Bundle version?  | next (as minor)
| New feature?     | yes
| Bug fix?         | no

# Context

This PR introduce a new command called `scheduler:execute`, this command allows to executed tasks depending on a set of filters.
