### PR TITLE
feat(configuration) : tasks node validation

### DIFF
--- a/src/DependencyInjection/SchedulerBundleConfiguration.php
+++ b/src/DependencyInjection/SchedulerBundleConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace SchedulerBundle\DependencyInjection;
 
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -19,9 +20,9 @@ final class SchedulerBundleConfiguration implements ConfigurationInterface
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('scheduler_bundle');
+        $rootNode = $treeBuilder->getRootNode();
 
-        $treeBuilder
-            ->getRootNode()
+        $rootNode
                 ->beforeNormalization()
                     ->always(function (array $configuration): array {
                         if ((array_key_exists('tasks', $configuration)) && 0 !== count($configuration['tasks']) && !array_key_exists('transport', $configuration)) {
@@ -61,7 +62,6 @@ final class SchedulerBundleConfiguration implements ConfigurationInterface
                             ->end()
                         ->end()
                     ->end()
-                    ->append($this->addTasksSection())
                     ->scalarNode('lock_store')
                         ->info('The store used by every worker to prevent overlapping, by default, a FlockStore is created')
                         ->defaultValue(null)
@@ -74,92 +74,126 @@ final class SchedulerBundleConfiguration implements ConfigurationInterface
             ->end()
         ;
 
+        $this->addTasksSection($rootNode);
+
         return $treeBuilder;
     }
 
-    private function addTasksSection()
+    /**
+     * add the tasks section to configuration tree
+     */
+    private function addTasksSection(ArrayNodeDefinition $node): void
     {
-        $treeBuilder = new TreeBuilder('tasks');
+        $node
+            ->children()
+                ->arrayNode('tasks')
+                ->useAttributeAsKey('name')
+                ->normalizeKeys(false)
+                ->arrayPrototype()
+                    ->validate()
+                        ->always(function ($v) {
+                            if (0=== count($v['arguments'])) {
+                                unset($v['arguments']);
+                            }
 
-        return  $treeBuilder->getRootNode()
-            ->useAttributeAsKey('name')
-            ->normalizeKeys(false)
-            ->arrayPrototype()
-                ->validate()
-                    ->always(function ($v) {
-                        if (0=== count($v['arguments'])) {
-                            unset($v['arguments']);
-                        }
+                            if (0=== count($v['environment_variables'])) {
+                                unset($v['environment_variables']);
+                            }
 
-                        if (0=== count($v['tags'])) {
-                            unset($v['tags']);
-                        }
+                            if (0=== count($v['client_options'])) {
+                                unset($v['client_options']);
+                            }
 
-                        if (0=== count($v['options'])) {
-                            unset($v['options']);
-                        }
+                            if (0=== count($v['tags'])) {
+                                unset($v['tags']);
+                            }
 
-                        if (0=== count($v['tasks'])) {
-                            unset($v['tasks']);
-                        }
+                            if (0=== count($v['options'])) {
+                                unset($v['options']);
+                            }
 
-                        return $v;
-                    })
-                ->end()
-                ->validate()
-                    ->ifTrue(static fn ($v): bool => !in_array($v['type'], ['null', 'chained'], true)  && !isset($v['command']))
-                    ->then(static function (array $v): void {
-                        throw new InvalidConfigurationException(sprintf('You must specify the "command" if you define "%s" task type.', $v['type']));
-                    })
-                ->end()
-                ->validate()
-                    ->ifTrue(static fn ($v): bool => 'command' !== $v['type'] && isset($v['arguments']))
-                    ->thenInvalid('The "arguments" option can only be defined for "command" task type.')
-                ->end()
-                ->validate()
-                    ->ifTrue(static fn ($v): bool =>  'chained' === $v['type'] && !isset($v['tasks']))
-                    ->thenInvalid('The "chained" type requires that you provide tasks.')
-                ->end()
-                ->children()
-                    ->enumNode('type')
-                        ->info('The Task type to build')
-                        ->isRequired()
-                        ->values(['shell', 'null', 'http', 'command', 'chained'])
+                            if (0=== count($v['tasks'])) {
+                                unset($v['tasks']);
+                            }
+
+                            return $v;
+                        })
                     ->end()
-                    ->scalarNode('description')->end()
-                    ->variableNode('command')->end()
-                    ->arrayNode('arguments')
-                        ->info('arguments to passed to "command" task type')
-                        ->normalizeKeys(false)
-                        ->variablePrototype()->end()
+                    ->validate()
+                        ->ifTrue(static fn ($v): bool => in_array($v['type'], ['shell', 'command'], true)  && !isset($v['command']))
+                        ->then(static function (array $v): void {
+                            throw new InvalidConfigurationException(sprintf('You must specify the "command" if you define "%s" task type.', $v['type']));
+                        })
                     ->end()
-                    ->integerNode('priority')
-                         ->min(-1000)->max(1000)
+                    ->validate()
+                        ->ifTrue(static fn ($v): bool => 'http' === $v['type'] && !isset($v['url']))
+                        ->thenInvalid('You must specify the "url" if you define "http" task type.')
                     ->end()
-                    ->scalarNode('expression')->end()
-                    ->booleanNode('single_run')->end()
-                    ->booleanNode('output')->end()
-                    ->booleanNode('output_to_store')->end()
-                    ->arrayNode('options')
-                        ->useAttributeAsKey('name')
-                        ->normalizeKeys(false)
-                        ->variablePrototype()->end()
+                    ->validate()
+                        ->ifTrue(static fn ($v): bool => 'command' !== $v['type'] && isset($v['arguments']))
+                        ->thenInvalid('The "arguments" option can only be defined for "command" task type.')
                     ->end()
-                    ->arrayNode('tags')
-                        ->normalizeKeys(false)
-                        ->variablePrototype()->end()
+                    ->validate()
+                        ->ifTrue(static fn ($v): bool =>  'chained' === $v['type'] && !isset($v['tasks']))
+                        ->thenInvalid('The "chained" type requires that you provide tasks.')
                     ->end()
-                    ->scalarNode('timezone')->end()
-                    ->scalarNode('tracked')->end()
-                    ->scalarNode('state')->end()
-                    ->integerNode('nice')->end()
-                    ->integerNode('max_executions')->end()
-                    ->floatNode('max_duration')->end()
-                    ->integerNode('execution_delay')->end()
-                    ->arrayNode('tasks')
-                        ->info('Tasks list only available for "chained" type')
-                        ->normalizeKeys(false)
-                        ->prototype('variable')
+                    ->children()
+                        ->enumNode('type')
+                            ->info('The Task type to build')
+                            ->isRequired()
+                            ->values(['shell', 'null', 'http', 'command', 'chained'])
+                        ->end()
+                        ->scalarNode('description')->end()
+                        ->scalarNode('expression')->defaultValue('* * * * *')->end()
+                        ->integerNode('priority')
+                            ->min(-1000)->max(1000)
+                        ->end()
+                        ->booleanNode('single_run')->end()
+                        ->booleanNode('output')->end()
+                        ->booleanNode('output_to_store')->end()
+                        ->integerNode('nice')->end()
+                        ->integerNode('max_executions')->end()
+                        ->integerNode('execution_delay')->end()
+                        ->scalarNode('timezone')->end()
+                        ->scalarNode('tracked')->end()
+                        ->scalarNode('state')->end()
+                        ->floatNode('max_duration')->end()
+                        ->arrayNode('tags')
+                            ->normalizeKeys(false)
+                            ->variablePrototype()->end()
+                        ->end()
+                        ->variableNode('command')->info('The command to run. (shell|command type) ')->end()
+                         ->scalarNode('cwd')->info('The working directory to use. (shell type)')->end()
+                         ->arrayNode('environment_variables')
+                            ->info('environment_variables to passed. (shell type)')
+                            ->useAttributeAsKey('name')
+                            ->normalizeKeys(false)
+                            ->variablePrototype()->end()
+                        ->end()
+                        ->floatNode('timeout')->info('The timeout in seconds to disable. (shell type)')->end()
+                        ->arrayNode('arguments')
+                            ->info('arguments to passed. (command type)')
+                            ->normalizeKeys(false)
+                            ->variablePrototype()->end()
+                        ->end()
+                        ->arrayNode('options')
+                            ->info('options to passed. (command type)')
+                            ->useAttributeAsKey('name')
+                            ->normalizeKeys(false)
+                            ->variablePrototype()->end()
+                        ->end()
+                        ->scalarNode('url')->info('url (http type)')->end()
+                        ->scalarNode('method')->info('HTTP Method. (http type)')->end()
+                        ->arrayNode('client_options')
+                            ->info('HTTP client options. (http type)')
+                            ->useAttributeAsKey('name')
+                            ->normalizeKeys(false)
+                            ->variablePrototype()->end()
+                        ->end()
+                        ->arrayNode('tasks')
+                            ->info('Chained tasks. (chained type)')
+                            ->normalizeKeys(false)
+                            ->variablePrototype()->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/DependencyInjection/SchedulerBundleConfiguration.php
+++ b/src/DependencyInjection/SchedulerBundleConfiguration.php
@@ -8,10 +8,6 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use function array_key_exists;
-use function array_filter;
-use function array_map;
-use function array_replace;
-use function array_values;
 use function count;
 
 /**
@@ -65,27 +61,6 @@ final class SchedulerBundleConfiguration implements ConfigurationInterface
                         ->end()
                     ->end()
                     ->arrayNode('tasks')
-                        ->beforeNormalization()
-                            ->always(function (array $taskConfiguration): array {
-                                $chainedTasks = array_filter($taskConfiguration, fn (array $configuration): bool => 'chained' === $configuration['type'] && 0 !== count($configuration['tasks']));
-
-                                if (0 === count($chainedTasks)) {
-                                    return $taskConfiguration;
-                                }
-
-                                $updatedChainedTasks = array_map(function (array $chainedTaskConfiguration): array {
-                                    foreach ($chainedTaskConfiguration['tasks'] as $chainedTask => &$configuration) {
-                                        $configuration['name'] = $chainedTask;
-                                    }
-
-                                    $chainedTaskConfiguration['tasks'] = array_values($chainedTaskConfiguration['tasks']);
-
-                                    return $chainedTaskConfiguration;
-                                }, $chainedTasks);
-
-                                return array_replace($taskConfiguration, $updatedChainedTasks);
-                            })
-                        ->end()
                         ->useAttributeAsKey('name')
                         ->normalizeKeys(false)
                             ->variablePrototype()->end()

--- a/src/Task/Builder/ChainedBuilder.php
+++ b/src/Task/Builder/ChainedBuilder.php
@@ -38,17 +38,17 @@ final class ChainedBuilder extends AbstractTaskBuilder implements BuilderInterfa
      */
     public function build(PropertyAccessorInterface $propertyAccessor, array $options = []): TaskInterface
     {
-        $chainedTask = new ChainedTask($options['name'], ...array_map(function (array $task) use ($propertyAccessor): TaskInterface {
+        $chainedTask = new ChainedTask($options['name'], ...array_map(function (string $name, array $task) use ($propertyAccessor): TaskInterface {
             foreach ($this->builders as $builder) {
                 if (!$builder->support($task['type'])) {
                     continue;
                 }
 
-                return $builder->build($propertyAccessor, $task);
+                return $builder->build($propertyAccessor, array_merge(['name' => $name], $task));
             }
 
             throw new InvalidArgumentException('The given task cannot be created as no related builder can be found');
-        }, $options['tasks']));
+        }, array_keys($options['tasks']), $options['tasks']));
 
         unset($options['tasks']);
 

--- a/tests/DependencyInjection/SchedulerBundleConfigurationTest.php
+++ b/tests/DependencyInjection/SchedulerBundleConfigurationTest.php
@@ -168,6 +168,25 @@ final class SchedulerBundleConfigurationTest extends TestCase
         ]);
     }
 
+    public function testConfigurationCannotDefineHttpTaskWithoutUrl(): void
+    {
+        self::expectException(InvalidConfigurationException::class);
+        self::expectExceptionMessage('You must specify the "url" if you define "http" task type');
+        self::expectExceptionCode(0);
+        (new Processor())->processConfiguration(new SchedulerBundleConfiguration(), [
+            'scheduler_bundle' => [
+                'transport' => [
+                    'dsn' => 'cache://app',
+                ],
+                'tasks' => [
+                    'foo' => [
+                        'type' => 'http',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
     public function testConfigurationCanDefineChainedTasks(): void
     {
         $configuration = (new Processor())->processConfiguration(new SchedulerBundleConfiguration(), [
@@ -207,6 +226,129 @@ final class SchedulerBundleConfigurationTest extends TestCase
         self::assertSame('shell', $configuration['tasks']['random']['tasks']['foo']['type']);
         self::assertArrayHasKey('bar', $configuration['tasks']['random']['tasks']);
         self::assertSame('command', $configuration['tasks']['random']['tasks']['bar']['type']);
+    }
+
+    public function testConfigurationCanDefineCommandTask(): void
+    {
+        $configuration = (new Processor())->processConfiguration(new SchedulerBundleConfiguration(), [
+            'scheduler_bundle' => [
+                'transport' => [
+                    'dsn' => 'cache://app',
+                ],
+                'tasks' => [
+                    'foo' => [
+                        'type' => 'command',
+                        'description' => 'simple command task',
+                        'expression' => '*/5 * * * *',
+                        'command' => 'cache:clear',
+                        'arguments' => ['arg1', 'arg2'],
+                        'options' => ['env' =>'test', '--help', 'version'],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertCount(1, $configuration['tasks']);
+        self::assertArrayHasKey('foo', $configuration['tasks']);
+        self::assertSame('command', $configuration['tasks']['foo']['type']);
+        self::assertSame('simple command task', $configuration['tasks']['foo']['description']);
+        self::assertSame('*/5 * * * *', $configuration['tasks']['foo']['expression']);
+        self::assertSame('cache:clear', $configuration['tasks']['foo']['command']);
+        self::assertEquals([
+            'arg1',
+            'arg2',
+        ], $configuration['tasks']['foo']['arguments']);
+        self::assertEquals([
+            "env" => "test",
+            "--help",
+            "version",
+        ], $configuration['tasks']['foo']['options']);
+    }
+
+    public function testConfigurationCanDefineHttpTask(): void
+    {
+        $configuration = (new Processor())->processConfiguration(new SchedulerBundleConfiguration(), [
+            'scheduler_bundle' => [
+                'transport' => [
+                    'dsn' => 'cache://app',
+                ],
+                'tasks' => [
+                    'foo' => [
+                        'type' => 'http',
+                        'description' => 'simple http task',
+                        'expression' => '*/5 * * * *',
+                        'url' => 'https://symfony.com',
+                        'method' => 'GET',
+                        'client_options' => ['header' =>['User-Agent', 'My Fancy App']],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertCount(1, $configuration['tasks']);
+        self::assertArrayHasKey('foo', $configuration['tasks']);
+        self::assertSame('http', $configuration['tasks']['foo']['type']);
+        self::assertSame('simple http task', $configuration['tasks']['foo']['description']);
+        self::assertSame('*/5 * * * *', $configuration['tasks']['foo']['expression']);
+        self::assertSame('GET', $configuration['tasks']['foo']['method']);
+        self::assertEquals([
+            'header' =>[
+                'User-Agent',
+                'My Fancy App',
+            ],
+        ], $configuration['tasks']['foo']['client_options']);
+    }
+
+    public function testConfigurationCanDefineNullTask(): void
+    {
+        $configuration = (new Processor())->processConfiguration(new SchedulerBundleConfiguration(), [
+            'scheduler_bundle' => [
+                'transport' => [
+                    'dsn' => 'cache://app',
+                ],
+                'tasks' => [
+                    'foo' => [
+                        'type' => 'null',
+                        'description' => 'simple null task',
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertCount(1, $configuration['tasks']);
+        self::assertArrayHasKey('foo', $configuration['tasks']);
+        self::assertSame('null', $configuration['tasks']['foo']['type']);
+        self::assertSame('simple null task', $configuration['tasks']['foo']['description']);
+    }
+
+    public function testConfigurationCanDefineShellTask(): void
+    {
+        $configuration = (new Processor())->processConfiguration(new SchedulerBundleConfiguration(), [
+            'scheduler_bundle' => [
+                'transport' => [
+                    'dsn' => 'cache://app',
+                ],
+                'tasks' => [
+                    'foo' => [
+                        'type' => 'shell',
+                        'description' => 'simple shell task',
+                        'expression' => '*/5 * * * *',
+                        'command' => ['ls', '-al'],
+                        'cwd' =>'/tmp',
+                        'environment_variables' => ['APP_ENV' => 'test'],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertCount(1, $configuration['tasks']);
+        self::assertArrayHasKey('foo', $configuration['tasks']);
+        self::assertSame('shell', $configuration['tasks']['foo']['type']);
+        self::assertSame('simple shell task', $configuration['tasks']['foo']['description']);
+        self::assertSame('*/5 * * * *', $configuration['tasks']['foo']['expression']);
+        self::assertEquals(['ls', '-al'], $configuration['tasks']['foo']['command']);
+        self::assertSame('/tmp', $configuration['tasks']['foo']['cwd']);
+        self::assertEquals(['APP_ENV' => 'test'], $configuration['tasks']['foo']['environment_variables']);
     }
 
     public function testConfigurationCanDefineSpecificRateLimiter(): void

--- a/tests/DependencyInjection/SchedulerBundleConfigurationTest.php
+++ b/tests/DependencyInjection/SchedulerBundleConfigurationTest.php
@@ -48,6 +48,125 @@ final class SchedulerBundleConfigurationTest extends TestCase
         ]);
     }
 
+    public function testConfigurationCannotDefineChainedTaskWithoutTasks(): void
+    {
+        self::expectException(InvalidConfigurationException::class);
+        self::expectExceptionMessage('The "chained" type requires that you provide tasks.');
+        self::expectExceptionCode(0);
+        (new Processor())->processConfiguration(new SchedulerBundleConfiguration(), [
+            'scheduler_bundle' => [
+                'transport' => [
+                    'dsn' => 'cache://app',
+                ],
+                'tasks' => [
+                    'foo' => [
+                        'type' => 'chained',
+                        'expression' => '*/5 * * * *',
+                        'description' => 'A chained task',
+                        'options' => [
+                            'env' => 'test',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testConfigurationCannotDefineShellTaskWithArguments(): void
+    {
+        self::expectException(InvalidConfigurationException::class);
+        self::expectExceptionMessage('The "arguments" option can only be defined for "command" task type.');
+        self::expectExceptionCode(0);
+        (new Processor())->processConfiguration(new SchedulerBundleConfiguration(), [
+            'scheduler_bundle' => [
+                'transport' => [
+                    'dsn' => 'cache://app',
+                ],
+                'tasks' => [
+                    'foo' => [
+                        'type' => 'shell',
+                        'arguments' => ['arg'],
+                        'command' => ['ls', '-al'],
+                        'expression' => '*/5 * * * *',
+                        'description' => 'A shell task with args',
+                        'options' => [
+                            'env' => 'test',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testConfigurationCannotDefineShellTaskWithoutCommand(): void
+    {
+        self::expectException(InvalidConfigurationException::class);
+        self::expectExceptionMessage('You must specify the "command" if you define "shell" task type.');
+        self::expectExceptionCode(0);
+        (new Processor())->processConfiguration(new SchedulerBundleConfiguration(), [
+            'scheduler_bundle' => [
+                'transport' => [
+                    'dsn' => 'cache://app',
+                ],
+                'tasks' => [
+                    'foo' => [
+                        'type' => 'shell',
+                        'arguments' => ['arg'],
+                        'expression' => '*/5 * * * *',
+                        'description' => 'A shell task with args',
+                        'options' => [
+                            'env' => 'test',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testConfigurationCannotDefinePriorityOutOfRange(): void
+    {
+        self::expectException(InvalidConfigurationException::class);
+        self::expectExceptionMessage('The value -2000 is too small for path "scheduler_bundle.tasks.foo.priority". Should be greater than or equal to -1000');
+        self::expectExceptionCode(0);
+        (new Processor())->processConfiguration(new SchedulerBundleConfiguration(), [
+            'scheduler_bundle' => [
+                'transport' => [
+                    'dsn' => 'cache://app',
+                ],
+                'tasks' => [
+                    'foo' => [
+                        'type' => 'shell',
+                        'expression' => '*/5 * * * *',
+                        'priority' => -2000,
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    public function testConfigurationCannotDefineCommandTaskWithoutCommand(): void
+    {
+        self::expectException(InvalidConfigurationException::class);
+        self::expectExceptionMessage('You must specify the "command" if you define "command" task type.');
+        self::expectExceptionCode(0);
+        (new Processor())->processConfiguration(new SchedulerBundleConfiguration(), [
+            'scheduler_bundle' => [
+                'transport' => [
+                    'dsn' => 'cache://app',
+                ],
+                'tasks' => [
+                    'foo' => [
+                        'type' => 'command',
+                        'expression' => '*/5 * * * *',
+                        'description' => 'A shell task with args',
+                        'options' => [
+                            'env' => 'test',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+    }
 
     public function testConfigurationCanDefineChainedTasks(): void
     {

--- a/tests/DependencyInjection/SchedulerBundleConfigurationTest.php
+++ b/tests/DependencyInjection/SchedulerBundleConfigurationTest.php
@@ -84,10 +84,10 @@ final class SchedulerBundleConfigurationTest extends TestCase
         self::assertArrayHasKey('random', $configuration['tasks']);
         self::assertCount(2, $configuration['tasks']['random']['tasks']);
         self::assertSame('chained', $configuration['tasks']['random']['type']);
-        self::assertSame('foo', $configuration['tasks']['random']['tasks'][0]['name']);
-        self::assertSame('shell', $configuration['tasks']['random']['tasks'][0]['type']);
-        self::assertSame('bar', $configuration['tasks']['random']['tasks'][1]['name']);
-        self::assertSame('command', $configuration['tasks']['random']['tasks'][1]['type']);
+        self::assertArrayHasKey('foo', $configuration['tasks']['random']['tasks']);
+        self::assertSame('shell', $configuration['tasks']['random']['tasks']['foo']['type']);
+        self::assertArrayHasKey('bar', $configuration['tasks']['random']['tasks']);
+        self::assertSame('command', $configuration['tasks']['random']['tasks']['bar']['type']);
     }
 
     public function testConfigurationCanDefineSpecificRateLimiter(): void

--- a/tests/DependencyInjection/SchedulerBundleExtensionTest.php
+++ b/tests/DependencyInjection/SchedulerBundleExtensionTest.php
@@ -920,6 +920,7 @@ final class SchedulerBundleExtensionTest extends TestCase
             'tasks' => [
                 'foo' => [
                     'type' => 'chained',
+                    'expression' => '* * * * *',
                     'tasks' => [
                         'bar' => [
                             'type' => 'shell',
@@ -938,6 +939,7 @@ final class SchedulerBundleExtensionTest extends TestCase
         self::assertEquals([
             'name' => 'foo',
             'type' => 'chained',
+            'expression' => '* * * * *',
             'tasks' => [
                 'bar' => [
                     'type' => 'shell',

--- a/tests/DependencyInjection/SchedulerBundleExtensionTest.php
+++ b/tests/DependencyInjection/SchedulerBundleExtensionTest.php
@@ -939,13 +939,11 @@ final class SchedulerBundleExtensionTest extends TestCase
             'name' => 'foo',
             'type' => 'chained',
             'tasks' => [
-                [
-                    'name' => 'bar',
+                'bar' => [
                     'type' => 'shell',
                     'expression' => '* * * * *',
                 ],
-                [
-                    'name' => 'random',
+                'random' => [
                     'type' => 'shell',
                     'expression' => '*/5 * * * *',
                 ],


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | 7.4
| Bundle version?  | 0.4.2
| New feature?     | yes
| Bug fix?         | no
| Discussion?      | # ...

Improve the validation of the configuration.

I would like to implement validation on the definition of tasks in the application. 
Before going further, I realized that it was possible to simplify the configuration of subtasks while keeping the same operation as the basic tasks.

I don't want to upset your plans and I don't know if I'm doing the right thing by proposing this PR but I find this bundle very useful and I'm happy to be able to give a hand. 

If you think it's derogatory, don't hesitate to let me know.
