### PR TITLE
feat(orchestrator) : sort nested tasks (ChainedTask)

### DIFF
--- a/src/SchedulePolicy/SchedulePolicyOrchestrator.php
+++ b/src/SchedulePolicy/SchedulePolicyOrchestrator.php
@@ -6,6 +6,7 @@ namespace SchedulerBundle\SchedulePolicy;
 
 use InvalidArgumentException;
 use RuntimeException;
+use SchedulerBundle\Task\ChainedTask;
 use SchedulerBundle\Task\TaskInterface;
 use function count;
 use function sprintf;
@@ -41,6 +42,12 @@ final class SchedulePolicyOrchestrator implements SchedulePolicyOrchestratorInte
 
         if (0 === count($tasks)) {
             return [];
+        }
+
+        foreach ($tasks as $task) {
+            if ($task instanceof ChainedTask) {
+                $task->setTasks(...$this->sort($policy, $task->getTasks()));
+            }
         }
 
         foreach ($this->policies as $schedulePolicy) {

--- a/tests/SchedulePolicy/SchedulePolicyOrchestratorTest.php
+++ b/tests/SchedulePolicy/SchedulePolicyOrchestratorTest.php
@@ -153,7 +153,7 @@ final class SchedulePolicyOrchestratorTest extends TestCase
         ], $schedulePolicyOrchestrator->sort('first_in_last_out', ['foo' => $secondTask, 'app' => $task]));
     }
 
-    public function testSchedulePolicyCanBeSortTasksUsingIdle(): void
+    public function testSchedulePolicyCanSortTasksUsingIdle(): void
     {
         $schedulePolicyOrchestrator = new SchedulePolicyOrchestrator([
             new FirstInFirstOutPolicy(),
@@ -172,7 +172,7 @@ final class SchedulePolicyOrchestratorTest extends TestCase
         self::assertSame(['foo' => $task, 'app' => $secondTask], $tasks);
     }
 
-    public function testSchedulePolicyCanBeSortTasksUsingMemoryUsage(): void
+    public function testSchedulePolicyCanSortTasksUsingMemoryUsage(): void
     {
         $schedulePolicyOrchestrator = new SchedulePolicyOrchestrator([
             new FirstInFirstOutPolicy(),

--- a/tests/SchedulePolicy/SchedulePolicyOrchestratorTest.php
+++ b/tests/SchedulePolicy/SchedulePolicyOrchestratorTest.php
@@ -270,6 +270,9 @@ final class SchedulePolicyOrchestratorTest extends TestCase
         $secondTask->expects(self::once())->method('getExecutionAbsoluteDeadline')->willReturn(new DateInterval('P2D'));
 
         $chainedTask = new ChainedTask('nested');
+        $chainedTask->setArrivalTime(new DateTimeImmutable());
+        $chainedTask->setExecutionStartTime(new DateTimeImmutable());
+        $chainedTask->setExecutionRelativeDeadline(new DateInterval('P1D'));
         $chainedTask->setTasks(...[$secondTask, $task]);
 
         $schedulePolicyOrchestrator->sort('deadline', [$chainedTask]);

--- a/tests/SchedulePolicy/SchedulePolicyOrchestratorTest.php
+++ b/tests/SchedulePolicy/SchedulePolicyOrchestratorTest.php
@@ -260,9 +260,13 @@ final class SchedulePolicyOrchestratorTest extends TestCase
         ]);
 
         $task = $this->createMock(TaskInterface::class);
+        $task->expects(self::exactly(2))->method('getArrivalTime')->willReturn(new DateTimeImmutable('+ 1 month'));
+        $task->expects(self::exactly(2))->method('getExecutionRelativeDeadline')->willReturn(new DateInterval('P2D'));
         $task->expects(self::once())->method('getExecutionAbsoluteDeadline')->willReturn(new DateInterval('P3D'));
 
         $secondTask = $this->createMock(TaskInterface::class);
+        $secondTask->expects(self::exactly(2))->method('getArrivalTime')->willReturn(new DateTimeImmutable('+ 1 month'));
+        $secondTask->expects(self::exactly(2))->method('getExecutionRelativeDeadline')->willReturn(new DateInterval('P2D'));
         $secondTask->expects(self::once())->method('getExecutionAbsoluteDeadline')->willReturn(new DateInterval('P2D'));
 
         $chainedTask = new ChainedTask('nested');


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | 7.4
| Bundle version?  | 0.4.2
| New feature?     | yes
| Bug fix?         | no
| Discussion?      | #69 #76

sort the embedded tasks using the same `execution_mode` as for the simple tasks.
