### PR TITLE
refactor(worker): proposal/ideas 

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -13,7 +13,6 @@ return $config->setRules([
     '@PSR2' => true,
     '@PSR12' => true,
     '@PHP74Migration' => true,
-    'strict_param' => true,
     'array_indentation' => true,
     'array_syntax' => [
         'syntax' => 'short',

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,8 @@
             "Tests\\SchedulerBundle\\Test\\Constraint\\": "tests/Test/Constraint/",
             "Tests\\SchedulerBundle\\Transport\\": "tests/Transport/",
             "Tests\\SchedulerBundle\\Transport\\Configuration\\": "tests/Transport/Configuration/",
-            "Tests\\SchedulerBundle\\Worker\\": "tests/Worker/"
+            "Tests\\SchedulerBundle\\Worker\\": "tests/Worker/",
+            "Tests\\SchedulerBundle\\Worker\\Assets\\": "tests/Worker/Assets/"
         }
     },
     "config": {

--- a/src/DependencyInjection/SchedulerBundleExtension.php
+++ b/src/DependencyInjection/SchedulerBundleExtension.php
@@ -118,6 +118,7 @@ use function strpos;
 final class SchedulerBundleExtension extends Extension
 {
     private const RUNNER_TAG = 'scheduler.runner';
+    private const TRANSPORT_FACTORY_TAG = 'scheduler.transport_factory';
 
     public function load(array $configs, ContainerBuilder $container): void
     {
@@ -186,7 +187,7 @@ final class SchedulerBundleExtension extends Extension
 
         $container->register(InMemoryTransportFactory::class, InMemoryTransportFactory::class)
             ->setPublic(false)
-            ->addTag('scheduler.transport_factory')
+            ->addTag(self::TRANSPORT_FACTORY_TAG)
             ->addTag('container.preload', [
                 'class' => InMemoryTransportFactory::class,
             ])
@@ -194,7 +195,7 @@ final class SchedulerBundleExtension extends Extension
 
         $container->register(FilesystemTransportFactory::class, FilesystemTransportFactory::class)
             ->setPublic(false)
-            ->addTag('scheduler.transport_factory')
+            ->addTag(self::TRANSPORT_FACTORY_TAG)
             ->addTag('container.preload', [
                 'class' => FilesystemTransportFactory::class,
             ])
@@ -205,7 +206,7 @@ final class SchedulerBundleExtension extends Extension
                 new TaggedIteratorArgument('scheduler.transport_factory'),
             ])
             ->setPublic(false)
-            ->addTag('scheduler.transport_factory')
+            ->addTag(self::TRANSPORT_FACTORY_TAG)
             ->addTag('container.preload', [
                 'class' => FailOverTransportFactory::class,
             ])
@@ -216,7 +217,7 @@ final class SchedulerBundleExtension extends Extension
                 new TaggedIteratorArgument('scheduler.transport_factory'),
             ])
             ->setPublic(false)
-            ->addTag('scheduler.transport_factory')
+            ->addTag(self::TRANSPORT_FACTORY_TAG)
             ->addTag('container.preload', [
                 'class' => LongTailTransportFactory::class,
             ])
@@ -227,7 +228,7 @@ final class SchedulerBundleExtension extends Extension
                 new TaggedIteratorArgument('scheduler.transport_factory'),
             ])
             ->setPublic(false)
-            ->addTag('scheduler.transport_factory')
+            ->addTag(self::TRANSPORT_FACTORY_TAG)
             ->addTag('container.preload', [
                 'class' => RoundRobinTransportFactory::class,
             ])

--- a/src/DependencyInjection/SchedulerBundleExtension.php
+++ b/src/DependencyInjection/SchedulerBundleExtension.php
@@ -117,6 +117,8 @@ use function strpos;
  */
 final class SchedulerBundleExtension extends Extension
 {
+    private const RUNNER_TAG = 'scheduler.runner';
+
     public function load(array $configs, ContainerBuilder $container): void
     {
         $schedulerBundleConfiguration = new SchedulerBundleConfiguration();
@@ -580,7 +582,7 @@ final class SchedulerBundleExtension extends Extension
         ;
 
         $container->register(ShellTaskRunner::class, ShellTaskRunner::class)
-            ->addTag('scheduler.runner')
+            ->addTag(self::RUNNER_TAG)
             ->addTag('container.preload', [
                 'class' => ShellTaskRunner::class,
             ])
@@ -590,14 +592,14 @@ final class SchedulerBundleExtension extends Extension
             ->setArguments([
                 new Reference('scheduler.application', ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE),
             ])
-            ->addTag('scheduler.runner')
+            ->addTag(self::RUNNER_TAG)
             ->addTag('container.preload', [
                 'class' => CommandTaskRunner::class,
             ])
         ;
 
         $container->register(CallbackTaskRunner::class, CallbackTaskRunner::class)
-            ->addTag('scheduler.runner')
+            ->addTag(self::RUNNER_TAG)
             ->addTag('container.preload', [
                 'class' => CallbackTaskRunner::class,
             ])
@@ -607,7 +609,7 @@ final class SchedulerBundleExtension extends Extension
             ->setArguments([
                 new Reference(HttpClientInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE),
             ])
-            ->addTag('scheduler.runner')
+            ->addTag(self::RUNNER_TAG)
             ->addTag('scheduler.extra', [
                 'require' => 'http_client',
                 'tag' => 'scheduler.runner',
@@ -621,7 +623,7 @@ final class SchedulerBundleExtension extends Extension
             ->setArguments([
                 new Reference(MessageBusInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE),
             ])
-            ->addTag('scheduler.runner')
+            ->addTag(self::RUNNER_TAG)
             ->addTag('scheduler.extra', [
                 'require' => 'messenger.default_bus',
                 'tag' => 'scheduler.runner',
@@ -635,7 +637,7 @@ final class SchedulerBundleExtension extends Extension
             ->setArguments([
                 new Reference(NotifierInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE),
             ])
-            ->addTag('scheduler.runner')
+            ->addTag(self::RUNNER_TAG)
             ->addTag('scheduler.extra', [
                 'require' => 'notifier',
                 'tag' => 'scheduler.runner',
@@ -646,7 +648,7 @@ final class SchedulerBundleExtension extends Extension
         ;
 
         $container->register(NullTaskRunner::class, NullTaskRunner::class)
-            ->addTag('scheduler.runner')
+            ->addTag(self::RUNNER_TAG)
             ->addTag('container.preload', [
                 'class' => NullTaskRunner::class,
             ])
@@ -656,7 +658,7 @@ final class SchedulerBundleExtension extends Extension
             ->setArguments([
                 new TaggedIteratorArgument('scheduler.runner'),
             ])
-            ->addTag('scheduler.runner')
+            ->addTag(self::RUNNER_TAG)
             ->addTag('container.preload', [
                 'class' => ChainedTaskRunner::class,
             ])

--- a/src/Runner/CommandTaskRunner.php
+++ b/src/Runner/CommandTaskRunner.php
@@ -8,13 +8,10 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\BufferedOutput;
-use SchedulerBundle\Exception\UnrecognizedCommandException;
 use SchedulerBundle\Task\CommandTask;
 use SchedulerBundle\Task\Output;
 use SchedulerBundle\Task\TaskInterface;
 use Throwable;
-use function array_key_exists;
-use function get_class;
 use function implode;
 use function is_int;
 use function sprintf;
@@ -73,7 +70,7 @@ final class CommandTaskRunner implements RunnerInterface
 
     private function buildInput(CommandTask $commandTask): StringInput
     {
-        $command = $this->findCommand($commandTask->getCommand());
+        $command = $this->application->find($commandTask->getCommand());
 
         return new StringInput(sprintf('%s %s %s', $command->getName(), implode(' ', $commandTask->getArguments()), implode(' ', $this->buildOptions($commandTask))));
     }
@@ -92,21 +89,5 @@ final class CommandTaskRunner implements RunnerInterface
         }
 
         return $options;
-    }
-
-    private function findCommand(string $command): Command
-    {
-        $registeredCommands = $this->application->all();
-        if (array_key_exists($command, $registeredCommands)) {
-            return $registeredCommands[$command];
-        }
-
-        foreach ($registeredCommands as $registeredCommand) {
-            if ($command === get_class($registeredCommand)) {
-                return $registeredCommand;
-            }
-        }
-
-        throw new UnrecognizedCommandException(sprintf('The given command "%s" cannot be found!', $command));
     }
 }

--- a/src/Runner/CommandTaskRunner.php
+++ b/src/Runner/CommandTaskRunner.php
@@ -74,9 +74,8 @@ final class CommandTaskRunner implements RunnerInterface
     private function buildInput(CommandTask $commandTask): StringInput
     {
         $command = $this->findCommand($commandTask->getCommand());
-        $options = $this->buildOptions($commandTask);
 
-        return new StringInput(sprintf('%s %s %s', $command->getName(), implode(' ', $commandTask->getArguments()), implode(' ', $options)));
+        return new StringInput(sprintf('%s %s %s', $command->getName(), implode(' ', $commandTask->getArguments()), implode(' ', $this->buildOptions($commandTask))));
     }
 
     private function buildOptions(CommandTask $commandTask): array

--- a/src/Runner/MessengerTaskRunner.php
+++ b/src/Runner/MessengerTaskRunner.php
@@ -34,7 +34,7 @@ final class MessengerTaskRunner implements RunnerInterface
         }
 
         try {
-            if (null === $this->bus) {
+            if (!$this->bus instanceof MessageBusInterface) {
                 $task->setExecutionState(TaskInterface::ERRORED);
 
                 return new Output($task, 'The task cannot be handled as the bus is not defined', Output::ERROR);

--- a/src/Runner/NotificationTaskRunner.php
+++ b/src/Runner/NotificationTaskRunner.php
@@ -34,7 +34,7 @@ final class NotificationTaskRunner implements RunnerInterface
         }
 
         try {
-            if (null === $this->notifier) {
+            if (!$this->notifier instanceof NotifierInterface) {
                 $task->setExecutionState(TaskInterface::ERRORED);
 
                 return new Output($task, 'The task cannot be handled as the notifier is not defined', Output::ERROR);

--- a/src/Runner/RunnerInterface.php
+++ b/src/Runner/RunnerInterface.php
@@ -14,5 +14,10 @@ interface RunnerInterface
 {
     public function run(TaskInterface $task): Output;
 
+    /**
+     * Determine if a @param TaskInterface $task is supported by the runner.
+     *
+     * The determination process is totally up to the runner.
+     */
     public function support(TaskInterface $task): bool;
 }

--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -72,7 +72,7 @@ final class Scheduler implements SchedulerInterface
         $task->setScheduledAt($this->getSynchronizedCurrentDate());
         $task->setTimezone($task->getTimezone() ?? $this->timezone);
 
-        if (null !== $this->bus && $task->isQueued()) {
+        if ($this->bus instanceof MessageBusInterface && $task->isQueued()) {
             $this->bus->dispatch(new TaskMessage($task));
             $this->dispatch(new TaskScheduledEvent($task));
 
@@ -99,7 +99,7 @@ final class Scheduler implements SchedulerInterface
      */
     public function yieldTask(string $name, bool $async = false): void
     {
-        if ($async && null !== $this->bus) {
+        if ($async && $this->bus instanceof MessageBusInterface) {
             $this->bus->dispatch(new TaskToYieldMessage($name));
 
             return;
@@ -124,7 +124,7 @@ final class Scheduler implements SchedulerInterface
      */
     public function pause(string $taskName, bool $async = false): void
     {
-        if ($async && null !== $this->bus) {
+        if ($async && $this->bus instanceof MessageBusInterface) {
             $this->bus->dispatch(new TaskToPauseMessage($taskName));
 
             return;
@@ -213,7 +213,7 @@ final class Scheduler implements SchedulerInterface
 
     private function dispatch(Event $event): void
     {
-        if (null === $this->eventDispatcher) {
+        if (!$this->eventDispatcher instanceof EventDispatcherInterface) {
             return;
         }
 

--- a/src/Transport/FailOverTransport.php
+++ b/src/Transport/FailOverTransport.php
@@ -36,7 +36,7 @@ final class FailOverTransport extends AbstractTransport
         $this->defineOptions(array_merge([
             'mode' => 'normal',
         ], $options), [
-            'mode' => ['string'],
+            'mode' => 'string',
         ]);
 
         $this->transports = $transports;

--- a/src/Transport/RoundRobinTransport.php
+++ b/src/Transport/RoundRobinTransport.php
@@ -32,7 +32,7 @@ final class RoundRobinTransport extends AbstractTransport
         $this->defineOptions(array_merge([
             'quantum' => $options['quantum'] ?? 2,
         ], $options), [
-            'quantum' => ['int'],
+            'quantum' => 'int',
         ]);
 
         $this->transports = $transports;

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -106,6 +106,9 @@ final class Worker implements WorkerInterface
                 }
 
                 $lockedTask = $this->lockFactory->createLock($task->getName());
+                if (!$lockedTask->acquire()) {
+                    continue;
+                }
 
                 $this->dispatch(new WorkerRunningEvent($this));
 
@@ -121,7 +124,7 @@ final class Worker implements WorkerInterface
                     try {
                         $this->middlewareStack->runPreExecutionMiddleware($task);
 
-                        if ($lockedTask->acquire() && !$this->options['isRunning']) {
+                        if (!$this->options['isRunning']) {
                             $this->options['isRunning'] = true;
                             $this->dispatch(new WorkerRunningEvent($this));
                             $this->handleTask($runner, $task);

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -258,7 +258,7 @@ final class Worker implements WorkerInterface
 
     private function dispatch(Event $event): void
     {
-        if (null === $this->eventDispatcher) {
+        if (!$this->eventDispatcher instanceof EventDispatcherInterface) {
             return;
         }
 

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -122,15 +122,15 @@ final class Worker implements WorkerInterface
                     }
 
                     try {
-                        $this->middlewareStack->runPreExecutionMiddleware($task);
-
                         if ($lockedTask->acquire(true) && !$this->options['isRunning']) {
+                            $this->middlewareStack->runPreExecutionMiddleware($task);
+
                             $this->options['isRunning'] = true;
                             $this->dispatch(new WorkerRunningEvent($this));
                             $this->handleTask($runner, $task);
-                        }
 
-                        $this->middlewareStack->runPostExecutionMiddleware($task);
+                            $this->middlewareStack->runPostExecutionMiddleware($task);
+                        }
                     } catch (Throwable $throwable) {
                         $failedTask = new FailedTask($task, $throwable->getMessage());
                         $this->failedTasks->add($failedTask);

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -158,6 +158,7 @@ final class Worker implements WorkerInterface
                 }
 
                 $this->execute($options);
+                break;
             }
         }
 

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -124,7 +124,7 @@ final class Worker implements WorkerInterface
                     try {
                         $this->middlewareStack->runPreExecutionMiddleware($task);
 
-                        if (!$this->options['isRunning']) {
+                        if ($lockedTask->acquire(true) && !$this->options['isRunning']) {
                             $this->options['isRunning'] = true;
                             $this->dispatch(new WorkerRunningEvent($this));
                             $this->handleTask($runner, $task);

--- a/src/Worker/WorkerInterface.php
+++ b/src/Worker/WorkerInterface.php
@@ -7,6 +7,7 @@ namespace SchedulerBundle\Worker;
 use SchedulerBundle\Event\TaskExecutedEvent;
 use SchedulerBundle\Event\TaskExecutingEvent;
 use SchedulerBundle\Event\TaskFailedEvent;
+use SchedulerBundle\Event\WorkerRestartedEvent;
 use SchedulerBundle\Event\WorkerStartedEvent;
 use SchedulerBundle\Event\WorkerStoppedEvent;
 use SchedulerBundle\Exception\UndefinedRunnerException;
@@ -41,8 +42,18 @@ interface WorkerInterface
 
     public function stop(): void;
 
+    /**
+     * Restart the worker, the actual restart process is dependant on the current implementation and/or context.
+     *
+     * Once the worker has been restarted, the {@see WorkerRestartedEvent} must be dispatched.
+     */
     public function restart(): void;
 
+    /**
+     * Determine if the worker is currently running (aka executing a task / set of tasks).
+     *
+     * The way the worker determine this informations is up to the worker / current context.
+     */
     public function isRunning(): bool;
 
     /**
@@ -52,6 +63,9 @@ interface WorkerInterface
      */
     public function getFailedTasks(): TaskListInterface;
 
+    /**
+     * @return TaskInterface|null The latest executed task or null if none has been executed.
+     */
     public function getLastExecutedTask(): ?TaskInterface;
 
     /**

--- a/src/Worker/WorkerInterface.php
+++ b/src/Worker/WorkerInterface.php
@@ -34,7 +34,7 @@ interface WorkerInterface
      *  - {@see WorkerOutputEvent}:  Contain the worker instance, the task and the {@see Output} after the execution.
      *  - {@see WorkerStoppedEvent}: Contain the worker instance AFTER executing the task.
      *
-     * @param array<string, int|string> $options
+     * @param array<string, int|string|bool> $options
      *
      * @throws UndefinedRunnerException if no runner capable of running the tasks is found
      */

--- a/src/Worker/WorkerInterface.php
+++ b/src/Worker/WorkerInterface.php
@@ -40,6 +40,15 @@ interface WorkerInterface
      */
     public function execute(array $options = [], TaskInterface ...$tasks): void;
 
+    /**
+     * Processes an array of tasks
+     *
+     * @internal
+     *
+     * @param TaskInterface[] $tasks
+     */
+    public function processTasks(array $tasks): void;
+
     public function stop(): void;
 
     /**

--- a/tests/Command/ConsumeTasksCommandTest.php
+++ b/tests/Command/ConsumeTasksCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\SchedulerBundle\Command;
 
+use DateTimeImmutable;
 use Exception;
 use ArrayIterator;
 use Generator;
@@ -328,6 +329,7 @@ final class ConsumeTasksCommandTest extends TestCase
 
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::once())->method('getExecutionComputationTime')->willReturn(10.05);
         $task->expects(self::once())->method('getExecutionMemoryUsage')->willReturn(9_507_552);
 
@@ -368,6 +370,7 @@ final class ConsumeTasksCommandTest extends TestCase
 
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(3))->method('getName')->willReturn('foo');
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::once())->method('getExecutionComputationTime')->willReturn(10.05);
         $task->expects(self::once())->method('getExecutionMemoryUsage')->willReturn(9_507_552);
 

--- a/tests/Worker/Assets/LongExecutionCommand.php
+++ b/tests/Worker/Assets/LongExecutionCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SchedulerBundle\Worker\Assets;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use function sleep;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class LongExecutionCommand extends Command
+{
+    /**
+     * @var string|null
+     */
+    protected static $defaultName = 'app:long';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        sleep(5);
+
+        return self::SUCCESS;
+    }
+}

--- a/tests/Worker/WorkerTest.php
+++ b/tests/Worker/WorkerTest.php
@@ -83,6 +83,23 @@ final class WorkerTest extends TestCase
         self::assertSame(5, $worker->getOptions()['sleepDurationDelay']);
         self::assertArrayHasKey('shouldStop', $worker->getOptions());
         self::assertTrue($worker->getOptions()['shouldStop']);
+
+        $worker->execute([
+            'shouldStop' => true,
+        ]);
+
+        self::assertArrayHasKey('sleepDurationDelay', $worker->getOptions());
+        self::assertSame(1, $worker->getOptions()['sleepDurationDelay']);
+        self::assertArrayHasKey('executedTasksCount', $worker->getOptions());
+        self::assertSame(0, $worker->getOptions()['executedTasksCount']);
+        self::assertArrayHasKey('isRunning', $worker->getOptions());
+        self::assertFalse($worker->getOptions()['isRunning']);
+        self::assertArrayHasKey('lastExecutedTask', $worker->getOptions());
+        self::assertNull($worker->getOptions()['lastExecutedTask']);
+        self::assertArrayHasKey('sleepUntilNextMinute', $worker->getOptions());
+        self::assertFalse($worker->getOptions()['sleepUntilNextMinute']);
+        self::assertArrayHasKey('shouldStop', $worker->getOptions());
+        self::assertTrue($worker->getOptions()['shouldStop']);
     }
 
     /**

--- a/tests/Worker/WorkerTest.php
+++ b/tests/Worker/WorkerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\SchedulerBundle\Worker;
 
+use DateTimeImmutable;
 use DateTimeZone;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
@@ -94,6 +95,7 @@ final class WorkerTest extends TestCase
 
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
 
         $scheduler = $this->createMock(SchedulerInterface::class);
         $scheduler->expects(self::never())->method('getTimezone');
@@ -168,6 +170,7 @@ final class WorkerTest extends TestCase
         $secondTask = $this->createMock(TaskInterface::class);
         $secondTask->expects(self::exactly(3))->method('getName')->willReturn('bar');
         $secondTask->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $secondTask->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $secondTask->expects(self::once())->method('isSingleRun')->willReturn(false);
         $secondTask->expects(self::once())->method('setArrivalTime');
         $secondTask->expects(self::once())->method('setExecutionStartTime');
@@ -215,6 +218,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::once())->method('isSingleRun')->willReturn(false);
         $task->expects(self::once())->method('setArrivalTime');
         $task->expects(self::once())->method('setExecutionStartTime');
@@ -252,6 +256,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(4))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::exactly(2))->method('getBeforeExecuting')->willReturn(fn (): bool => false);
         $task->expects(self::never())->method('isSingleRun');
         $task->expects(self::never())->method('setArrivalTime');
@@ -295,6 +300,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(4))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(2))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::exactly(2))->method('getBeforeExecuting')->willReturn(fn (): bool => false);
         $task->expects(self::never())->method('isSingleRun');
         $task->expects(self::never())->method('setArrivalTime');
@@ -306,6 +312,7 @@ final class WorkerTest extends TestCase
         $validTask->expects(self::exactly(2))->method('getName')->willReturn('bar');
         $validTask->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
         $validTask->expects(self::exactly(2))->method('getBeforeExecuting')->willReturn(fn (): bool => true);
+        $validTask->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $validTask->expects(self::once())->method('getAfterExecuting')->willReturn(null);
         $validTask->expects(self::once())->method('isSingleRun')->willReturn(false);
         $validTask->expects(self::once())->method('setArrivalTime');
@@ -349,6 +356,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::exactly(2))->method('getBeforeExecuting')->willReturn(fn (): bool => true);
         $task->expects(self::once())->method('isSingleRun')->willReturn(false);
         $task->expects(self::once())->method('setArrivalTime');
@@ -391,6 +399,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(4))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(2))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::once())->method('getBeforeExecuting')->willReturn(null);
         $task->expects(self::exactly(2))->method('getAfterExecuting')->willReturn(fn (): bool => false);
         $task->expects(self::once())->method('isSingleRun')->willReturn(false);
@@ -402,6 +411,7 @@ final class WorkerTest extends TestCase
         $validTask = $this->createMock(TaskInterface::class);
         $validTask->expects(self::any())->method('getName')->willReturn('bar');
         $validTask->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $validTask->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $validTask->expects(self::once())->method('getBeforeExecuting')->willReturn(null);
         $validTask->expects(self::exactly(2))->method('getAfterExecuting')->willReturn(fn (): bool => true);
         $validTask->expects(self::once())->method('isSingleRun')->willReturn(false);
@@ -456,6 +466,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::once())->method('getBeforeExecuting')->willReturn(null);
         $task->expects(self::exactly(2))->method('getAfterExecuting')->willReturn(fn (): bool => true);
         $task->expects(self::once())->method('isSingleRun')->willReturn(false);
@@ -500,6 +511,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::once())->method('isSingleRun')->willReturn(false);
         $task->expects(self::once())->method('setArrivalTime');
         $task->expects(self::once())->method('setExecutionStartTime');
@@ -540,6 +552,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::once())->method('isSingleRun')->willReturn(false);
         $task->expects(self::once())->method('setArrivalTime');
         $task->expects(self::once())->method('setExecutionStartTime');
@@ -575,6 +588,7 @@ final class WorkerTest extends TestCase
 
         $shellTask = new ShellTask('foo', ['echo', 'Symfony']);
         $shellTask->setExpression('* * * * *');
+        $shellTask->setScheduledAt(new DateTimeImmutable('- 1 month'));
         $shellTask->setSingleRun(true);
 
         $runner = $this->createMock(RunnerInterface::class);
@@ -611,6 +625,7 @@ final class WorkerTest extends TestCase
 
         $task = $this->createMock(TaskInterface::class);
         $task->method('getName')->willReturn('failed');
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
 
         $tracker = $this->createMock(TaskExecutionTrackerInterface::class);
         $tracker->expects(self::once())->method('startTracking')->with(self::equalTo($task));
@@ -653,6 +668,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::once())->method('getBeforeExecuting')->willReturn(null);
         $task->expects(self::once())->method('getBeforeExecutingNotificationBag')->willReturn(null);
         $task->expects(self::once())->method('isSingleRun')->willReturn(false);
@@ -703,6 +719,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::once())->method('getBeforeExecuting')->willReturn(null);
         $task->expects(self::exactly(2))->method('getBeforeExecutingNotificationBag')->willReturn(new NotificationTaskBag($notification, $recipient));
         $task->expects(self::once())->method('isSingleRun')->willReturn(false);
@@ -747,6 +764,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::once())->method('getBeforeExecuting')->willReturn(null);
         $task->expects(self::once())->method('getAfterExecutingNotificationBag')->willReturn(null);
         $task->expects(self::once())->method('isSingleRun')->willReturn(false);
@@ -794,6 +812,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::once())->method('getBeforeExecuting')->willReturn(null);
         $task->expects(self::exactly(2))->method('getAfterExecutingNotificationBag')->willReturn(new NotificationTaskBag($notification, $recipient));
         $task->expects(self::once())->method('isSingleRun')->willReturn(false);
@@ -835,6 +854,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::once())->method('isSingleRun')->willReturn(false);
         $task->expects(self::once())->method('setArrivalTime');
         $task->expects(self::once())->method('setExecutionStartTime');
@@ -870,6 +890,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::once())->method('isSingleRun')->willReturn(false);
         $task->expects(self::once())->method('setArrivalTime');
         $task->expects(self::once())->method('setExecutionStartTime');
@@ -916,6 +937,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(6))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::once())->method('isSingleRun')->willReturn(false);
         $task->expects(self::once())->method('setArrivalTime');
         $task->expects(self::once())->method('setExecutionStartTime');
@@ -968,6 +990,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::once())->method('getName')->willReturn('foo');
         $task->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('-1 month'));
         $task->expects(self::once())->method('isSingleRun')->willReturn(false);
         $task->expects(self::once())->method('setArrivalTime');
         $task->expects(self::once())->method('setExecutionStartTime');
@@ -1004,6 +1027,7 @@ final class WorkerTest extends TestCase
         $task = $this->createMock(TaskInterface::class);
         $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
         $task->expects(self::exactly(4))->method('getState')->willReturn(TaskInterface::ENABLED);
+        $task->expects(self::once())->method('getScheduledAt')->willReturn(new DateTimeImmutable('- 1 month'));
         $task->expects(self::never())->method('isSingleRun');
         $task->expects(self::once())->method('setArrivalTime');
         $task->expects(self::once())->method('setExecutionStartTime');
@@ -1096,6 +1120,7 @@ final class WorkerTest extends TestCase
         ]);
 
         $task = new CommandTask('foo', 'app:long');
+        $task->setScheduledAt(new DateTimeImmutable('- 1 month'));
         $task->setSingleRun(true);
 
         $scheduler = $this->createMock(SchedulerInterface::class);

--- a/tests/Worker/WorkerTest.php
+++ b/tests/Worker/WorkerTest.php
@@ -17,6 +17,7 @@ use SchedulerBundle\Middleware\WorkerMiddlewareStack;
 use SchedulerBundle\Runner\CommandTaskRunner;
 use SchedulerBundle\Task\CommandTask;
 use SchedulerBundle\Task\FailedTask;
+use SchedulerBundle\Task\TaskListInterface;
 use SchedulerBundle\TaskBag\NotificationTaskBag;
 use Symfony\Component\Console\Application;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -73,11 +74,14 @@ final class WorkerTest extends TestCase
 
         $worker->execute([
             'sleepDurationDelay' => 5,
+            'shouldStop' => true,
         ]);
 
         self::assertNotNull($worker->getOptions());
         self::assertArrayHasKey('sleepDurationDelay', $worker->getOptions());
         self::assertSame(5, $worker->getOptions()['sleepDurationDelay']);
+        self::assertArrayHasKey('shouldStop', $worker->getOptions());
+        self::assertTrue($worker->getOptions()['shouldStop']);
     }
 
     /**
@@ -134,8 +138,9 @@ final class WorkerTest extends TestCase
         $worker = new Worker($scheduler, [$runner], $watcher, new WorkerMiddlewareStack([
             new TaskUpdateMiddleware($scheduler),
         ]), $eventDispatcher, $logger);
-        $worker->stop();
-        $worker->execute();
+        $worker->execute([
+            'shouldStop' => true,
+        ]);
 
         self::assertNull($worker->getLastExecutedTask());
     }
@@ -279,6 +284,9 @@ final class WorkerTest extends TestCase
         self::assertSame($task, $worker->getLastExecutedTask());
     }
 
+    /**
+     * @throws Throwable {@see TaskListInterface::add()}
+     */
     public function testTaskCanBeExecutedWithErroredBeforeExecutionCallback(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
@@ -330,6 +338,9 @@ final class WorkerTest extends TestCase
         self::assertSame($validTask, $worker->getLastExecutedTask());
     }
 
+    /**
+     * @throws Throwable {@see TaskListInterface::add()}
+     */
     public function testTaskCanBeExecutedWithBeforeExecutionCallback(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
@@ -369,6 +380,9 @@ final class WorkerTest extends TestCase
         self::assertSame($task, $worker->getLastExecutedTask());
     }
 
+    /**
+     * @throws Throwable {@see TaskListInterface::add()}
+     */
     public function testTaskCanBeExecutedWithErroredAfterExecutionCallback(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
@@ -427,6 +441,9 @@ final class WorkerTest extends TestCase
         self::assertSame($validTask, $worker->getLastExecutedTask());
     }
 
+    /**
+     * @throws Throwable {@see TaskListInterface::add()}
+     */
     public function testTaskCanBeExecutedWithAfterExecutionCallback(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
@@ -468,6 +485,9 @@ final class WorkerTest extends TestCase
         self::assertSame($task, $worker->getLastExecutedTask());
     }
 
+    /**
+     * @throws Throwable {@see TaskListInterface::add()}
+     */
     public function testTaskCanBeExecutedWithRunner(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
@@ -505,6 +525,9 @@ final class WorkerTest extends TestCase
         self::assertSame($task, $worker->getLastExecutedTask());
     }
 
+    /**
+     * @throws Throwable {@see TaskListInterface::add()}
+     */
     public function testTaskCanBeExecutedAndTheWorkerCanReturnTheLastExecutedTask(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
@@ -542,6 +565,9 @@ final class WorkerTest extends TestCase
         self::assertSame($task, $worker->getLastExecutedTask());
     }
 
+    /**
+     * @throws Throwable {@see TaskListInterface::add()}
+     */
     public function testTaskCannotBeExecutedTwiceAsSingleRunTask(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
@@ -572,6 +598,9 @@ final class WorkerTest extends TestCase
         self::assertSame($shellTask, $worker->getLastExecutedTask());
     }
 
+    /**
+     * @throws Throwable {@see TaskListInterface::add()}
+     */
     public function testWorkerCanHandleFailedTask(): void
     {
         $runner = $this->createMock(RunnerInterface::class);
@@ -606,6 +635,9 @@ final class WorkerTest extends TestCase
         self::assertSame('Random error occurred', $failedTask->getReason());
     }
 
+    /**
+     * @throws Throwable {@see TaskListInterface::add()}
+     */
     public function testTaskCanBeExecutedWithoutBeforeExecutionNotificationAndNotifier(): void
     {
         $logger = $this->createMock(LoggerInterface::class);
@@ -650,6 +682,9 @@ final class WorkerTest extends TestCase
         self::assertSame($task, $worker->getLastExecutedTask());
     }
 
+    /**
+     * @throws Throwable {@see TaskListInterface::add()}
+     */
     public function testTaskCanBeExecutedWithBeforeExecutionNotificationAndNotifier(): void
     {
         $notification = $this->createMock(Notification::class);

--- a/tests/Worker/WorkerTest.php
+++ b/tests/Worker/WorkerTest.php
@@ -1039,4 +1039,11 @@ final class WorkerTest extends TestCase
 
         self::assertNull($worker->getLastExecutedTask());
     }
+
+    /**
+     * @group time-sensitive
+     */
+    public function testWorkerCanExecuteLongRunningTask(): void
+    {
+    }
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | 7.4
| Bundle version?  | 0.4.4
| New feature?     | no
| Bug fix?         | no
| Discussion?      | #92, #77, #102

I modified the execution method a bit. It's far from perfect, but it's easier for me than trying to present my ideas in English.
* remove shouldStop while loop
* add method for processing tasks 

This modification has the advantage of not dispatching the `WorkerStartedEvent` on each recursion.

I also isolated the process of running tasks, it could be useful to launch chained tasks more simply (I saw that you had started working on it #103)

```php
    public function run(TaskInterface $task, WorkerInterface $worker): Output
    {
        if (!$task instanceof ChainedTask) {
            $task->setExecutionState(TaskInterface::ERRORED);
            return new Output($task, null, Output::ERROR);
        }

        try {
            $worker->processTasks($task->getTasks());
        } catch (Throwable $throwable) {
            $task->setExecutionState(TaskInterface::ERRORED);
            return new Output($task, $throwable->getMessage(), Output::ERROR);
        }

        $task->setExecutionState(TaskInterface::SUCCEED);
        return new Output($task, null, Output::SUCCESS);
    }
```
I wondered about the interest of this while loop.

https://github.com/Guikingone/SchedulerBundle/blob/6eb5077d046b3051e82e488fe8e95185fcc629af/src/Worker/Worker.php#L102

I think it was useful only with the `--wait` option and does not add anything to a simple `consume`. 

These modifications are not satisfactory but I think that it allows to expose my visions to you and thus to exchange more easily 