### PR TITLE
fix(taskNormalizer): Normalize DateTime microseconds

### DIFF
--- a/src/Serializer/TaskNormalizer.php
+++ b/src/Serializer/TaskNormalizer.php
@@ -76,7 +76,7 @@ final class TaskNormalizer implements DenormalizerInterface, NormalizerInterface
             throw new InvalidArgumentException(sprintf('CallbackTask with closure cannot be sent to external transport, consider executing it thanks to "%s::execute()"', Worker::class));
         }
 
-        $dateAttributesCallback = fn (?DatetimeInterface $innerObject, TaskInterface $outerObject, string $attributeName, string $format = null, array $context = []): ?string => $innerObject instanceof DatetimeInterface ? $this->dateTimeNormalizer->normalize($innerObject, $format, $context) : null;
+        $dateAttributesCallback = fn (?DatetimeInterface $innerObject, TaskInterface $outerObject, string $attributeName, string $format = null, array $context = []): ?string => $innerObject instanceof DatetimeInterface ? $this->dateTimeNormalizer->normalize($innerObject, $format, array_merge([DateTimeNormalizer::FORMAT_KEY => "Y-m-d H:i:s.u"], $context)) : null;
         $dateIntervalAttributesCallback = fn (?DateInterval $innerObject, TaskInterface $outerObject, string $attributeName, string $format = null, array $context = []): ?string => $innerObject instanceof DateInterval ? $this->dateIntervalNormalizer->normalize($innerObject, $format, $context) : null;
         $notificationTaskBagCallback = fn (?NotificationTaskBag $innerObject, TaskInterface $outerObject, string $attributeName, string $format = null, array $context = []): ?array => $innerObject instanceof NotificationTaskBag ? $this->notificationTaskBagNormalizer->normalize($innerObject, $format, $context) : null;
         $taskCallbacksAttributesCallback = function ($innerObject, TaskInterface $outerObject, string $attributeName, string $format = null, array $context = []): ?array {

--- a/tests/SchedulePolicy/FirstInFirstOutPolicyTest.php
+++ b/tests/SchedulePolicy/FirstInFirstOutPolicyTest.php
@@ -65,4 +65,32 @@ final class FirstInFirstOutPolicyTest extends TestCase
             'foo' => $task,
         ], $firstInFirstOutPolicy->sort(['bar' => $secondTask, 'random' => $thirdTask, 'foo' => $task]));
     }
+
+    public function testTasksCanBeSortedUsingDefaultDate(): void
+    {
+        $task = new NullTask('qux', [
+            'scheduled_at' => new DateTimeImmutable(),
+        ]);
+
+        $secondTask = new NullTask('foo', [
+            'scheduled_at' => new DateTimeImmutable(),
+        ]);
+
+        $thirdTask = new NullTask('bar', [
+            'scheduled_at' => new DateTimeImmutable(),
+        ]);
+
+        $fourthTask = new NullTask('baz', [
+            'scheduled_at' => new DateTimeImmutable(),
+        ]);
+
+        $firstInFirstOutPolicy = new FirstInFirstOutPolicy();
+
+        self::assertSame([
+            'qux' => $task,
+            'foo' => $secondTask,
+            'bar' => $thirdTask,
+            'baz' => $fourthTask,
+        ], $firstInFirstOutPolicy->sort(['foo' => $secondTask, 'baz' => $fourthTask, 'bar' => $thirdTask, 'qux' => $task]));
+    }
 }

--- a/tests/Serializer/TaskNormalizerTest.php
+++ b/tests/Serializer/TaskNormalizerTest.php
@@ -188,9 +188,9 @@ final class TaskNormalizerTest extends TestCase
 
         $serializer = new Serializer([$notificationTaskBagNormalizer, new TaskNormalizer(new DateTimeNormalizer(), new DateTimeZoneNormalizer(), new DateIntervalNormalizer(), $objectNormalizer, $notificationTaskBagNormalizer), new DateTimeNormalizer(), new DateIntervalNormalizer(), new JsonSerializableNormalizer(), $objectNormalizer], [new JsonEncoder()]);
         $objectNormalizer->setSerializer($serializer);
-
+        $scheduledAt = new DateTimeImmutable();
         $task = new NullTask('foo');
-        $task->setScheduledAt(new DateTimeImmutable());
+        $task->setScheduledAt($scheduledAt);
 
         $data = $serializer->serialize($task, 'json');
         $task = $serializer->deserialize($data, TaskInterface::class, 'json');
@@ -198,6 +198,7 @@ final class TaskNormalizerTest extends TestCase
         self::assertInstanceOf(NullTask::class, $task);
         self::assertSame('* * * * *', $task->getExpression());
         self::assertInstanceOf(DateTimeImmutable::class, $task->getScheduledAt());
+        self::assertSame($scheduledAt->format("Y-m-d H:i:s.u"), $task->getScheduledAt()->format("Y-m-d H:i:s.u"));
     }
 
     public function testShellTaskWithBeforeSchedulingClosureCannotBeNormalized(): void


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | 7.4
| Bundle version?  | next (as patch)
| New feature?     | no
| Bug fix?         | yes
| Discussion?      | #106

indirectly a bug fix on the fifo sort for the filesystem #106

With this modification the `FilesystemTransportTest::testTaskListCanBeRetrieved` FIFO test turns green and microseconds are preserved during storage 😉 
