### PR TITLE
refactor(command): ExecuteTaskCommand - name option shortcut removed

### DIFF
--- a/src/Command/ExecuteTaskCommand.php
+++ b/src/Command/ExecuteTaskCommand.php
@@ -61,7 +61,7 @@ final class ExecuteTaskCommand extends Command
             ->setDescription('Execute tasks (due or not) depending on filters')
             ->setDefinition([
                 new InputOption('due', 'd', InputOption::VALUE_NONE, 'Define if the filters must be applied on due tasks'),
-                new InputOption('name', 'n', InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'The name of the task(s) to execute'),
+                new InputOption('name', null, InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'The name of the task(s) to execute'),
                 new InputOption('expression', null, InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'The expression of the task(s) to execute'),
                 new InputOption('tags', 't', InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'The tags of the task(s) to execute'),
             ])

--- a/tests/Command/ExecuteTaskCommandTest.php
+++ b/tests/Command/ExecuteTaskCommandTest.php
@@ -37,7 +37,7 @@ final class ExecuteTaskCommandTest extends TestCase
         self::assertFalse($command->getDefinition()->getOption('due')->acceptValue());
         self::assertSame('Define if the filters must be applied on due tasks', $command->getDefinition()->getOption('due')->getDescription());
         self::assertTrue($command->getDefinition()->hasOption('name'));
-        self::assertSame('n', $command->getDefinition()->getOption('name')->getShortcut());
+        self::assertNull($command->getDefinition()->getOption('name')->getShortcut());
         self::assertTrue($command->getDefinition()->getOption('name')->isValueOptional());
         self::assertTrue($command->getDefinition()->getOption('name')->isArray());
         self::assertSame('The name of the task(s) to execute', $command->getDefinition()->getOption('name')->getDescription());


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | 7.4
| Bundle version?  | 0.5.0
| New feature?     | no
| Bug fix?         | yes