### PR TITLE
refactor(DIC): MessengerTaskRunner injection fixed

### DIFF
--- a/src/DependencyInjection/SchedulerBundleExtension.php
+++ b/src/DependencyInjection/SchedulerBundleExtension.php
@@ -123,6 +123,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 use function array_key_exists;
 use function array_merge;
 use function class_exists;
+use function interface_exists;
 use function sprintf;
 use function strpos;
 
@@ -670,20 +671,6 @@ final class SchedulerBundleExtension extends Extension
             ])
         ;
 
-        $container->register(MessengerTaskRunner::class, MessengerTaskRunner::class)
-            ->setArguments([
-                new Reference(MessageBusInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE),
-            ])
-            ->addTag(self::SCHEDULER_RUNNER_TAG)
-            ->addTag('scheduler.extra', [
-                'require' => 'messenger.bus.default',
-                'tag' => self::SCHEDULER_RUNNER_TAG,
-            ])
-            ->addTag('container.preload', [
-                'class' => MessengerTaskRunner::class,
-            ])
-        ;
-
         $container->register(NotificationTaskRunner::class, NotificationTaskRunner::class)
             ->setArguments([
                 new Reference(NotifierInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE),
@@ -772,6 +759,18 @@ final class SchedulerBundleExtension extends Extension
                 'class' => TaskToPauseMessageHandler::class,
             ])
         ;
+
+        if (interface_exists(MessageBusInterface::class)) {
+            $container->register(MessengerTaskRunner::class, MessengerTaskRunner::class)
+                ->setArguments([
+                    new Reference(MessageBusInterface::class, ContainerInterface::NULL_ON_INVALID_REFERENCE),
+                ])
+                ->addTag(self::SCHEDULER_RUNNER_TAG)
+                ->addTag('container.preload', [
+                    'class' => MessengerTaskRunner::class,
+                ])
+            ;
+        }
     }
 
     private function registerSubscribers(ContainerBuilder $container): void

--- a/src/DependencyInjection/SchedulerBundleExtension.php
+++ b/src/DependencyInjection/SchedulerBundleExtension.php
@@ -676,7 +676,7 @@ final class SchedulerBundleExtension extends Extension
             ])
             ->addTag(self::SCHEDULER_RUNNER_TAG)
             ->addTag('scheduler.extra', [
-                'require' => 'messenger.default_bus',
+                'require' => 'messenger.bus.default',
                 'tag' => self::SCHEDULER_RUNNER_TAG,
             ])
             ->addTag('container.preload', [

--- a/src/Runner/MessengerTaskRunner.php
+++ b/src/Runner/MessengerTaskRunner.php
@@ -18,9 +18,9 @@ final class MessengerTaskRunner implements RunnerInterface
 {
     private ?MessageBusInterface $bus;
 
-    public function __construct(MessageBusInterface $messageBus = null)
+    public function __construct(MessageBusInterface $bus = null)
     {
-        $this->bus = $messageBus;
+        $this->bus = $bus;
     }
 
     /**

--- a/tests/DependencyInjection/SchedulerBundleExtensionTest.php
+++ b/tests/DependencyInjection/SchedulerBundleExtensionTest.php
@@ -742,12 +742,10 @@ final class SchedulerBundleExtensionTest extends TestCase
         self::assertCount(1, $container->getDefinition(MessengerTaskRunner::class)->getArguments());
         self::assertInstanceOf(Reference::class, $container->getDefinition(MessengerTaskRunner::class)->getArgument(0));
         self::assertSame(MessageBusInterface::class, (string) $container->getDefinition(MessengerTaskRunner::class)->getArgument(0));
+        self::assertSame(ContainerInterface::NULL_ON_INVALID_REFERENCE, $container->getDefinition(MessengerTaskRunner::class)->getArgument(0)->getInvalidBehavior());
         self::assertTrue($container->getDefinition(MessengerTaskRunner::class)->hasTag('scheduler.runner'));
         self::assertTrue($container->getDefinition(MessengerTaskRunner::class)->hasTag('container.preload'));
         self::assertSame(MessengerTaskRunner::class, $container->getDefinition(MessengerTaskRunner::class)->getTag('container.preload')[0]['class']);
-        self::assertTrue($container->getDefinition(MessengerTaskRunner::class)->hasTag('scheduler.extra'));
-        self::assertSame('messenger.bus.default', $container->getDefinition(MessengerTaskRunner::class)->getTag('scheduler.extra')[0]['require']);
-        self::assertSame('scheduler.runner', $container->getDefinition(MessengerTaskRunner::class)->getTag('scheduler.extra')[0]['tag']);
 
         self::assertTrue($container->hasDefinition(NotificationTaskRunner::class));
         self::assertCount(1, $container->getDefinition(NotificationTaskRunner::class)->getArguments());

--- a/tests/DependencyInjection/SchedulerBundleExtensionTest.php
+++ b/tests/DependencyInjection/SchedulerBundleExtensionTest.php
@@ -746,7 +746,7 @@ final class SchedulerBundleExtensionTest extends TestCase
         self::assertTrue($container->getDefinition(MessengerTaskRunner::class)->hasTag('container.preload'));
         self::assertSame(MessengerTaskRunner::class, $container->getDefinition(MessengerTaskRunner::class)->getTag('container.preload')[0]['class']);
         self::assertTrue($container->getDefinition(MessengerTaskRunner::class)->hasTag('scheduler.extra'));
-        self::assertSame('messenger.default_bus', $container->getDefinition(MessengerTaskRunner::class)->getTag('scheduler.extra')[0]['require']);
+        self::assertSame('messenger.bus.default', $container->getDefinition(MessengerTaskRunner::class)->getTag('scheduler.extra')[0]['require']);
         self::assertSame('scheduler.runner', $container->getDefinition(MessengerTaskRunner::class)->getTag('scheduler.extra')[0]['tag']);
 
         self::assertTrue($container->hasDefinition(NotificationTaskRunner::class));


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | 7.4
| Bundle version?  | 0.5.4
| New feature?     | yes
| Bug fix?         | yes

# Context

The `MessengerTaskRunner` isn't injected if the `messenger.bus.default` definition is not available, before, we've used `messenger.default_bus` which is the final alias and not the definition.

# Expected behaviour

The `MessengerTaskRunner` should be available if the bus is configured.

# Additional informations

Asked by @babeuloula 
