### PR TITLE
refactor(worker): stop sleeping worker

### DIFF
--- a/src/DependencyInjection/SchedulerBundleExtension.php
+++ b/src/DependencyInjection/SchedulerBundleExtension.php
@@ -669,7 +669,7 @@ final class SchedulerBundleExtension extends Extension
         ;
 
         $container->setDefinition(ChainedBuilder::class, new ChildDefinition(AbstractTaskBuilder::class))
-            ->setArgument(1, new TaggedIteratorArgument(self::SCHEDULER_TASK_BUILDER_TAG))
+            ->setArgument('$builders', new TaggedIteratorArgument(self::SCHEDULER_TASK_BUILDER_TAG))
             ->setPublic(false)
             ->addTag(self::SCHEDULER_TASK_BUILDER_TAG)
             ->addTag('container.preload', [

--- a/src/DependencyInjection/SchedulerBundleExtension.php
+++ b/src/DependencyInjection/SchedulerBundleExtension.php
@@ -967,7 +967,7 @@ final class SchedulerBundleExtension extends Extension
 
     private function registerDoctrineBridge(ContainerBuilder $container, array $configuration): void
     {
-        if (0 !== strpos($configuration['transport']['dsn'], 'doctrine://')) {
+        if (0 !== strpos($configuration['transport']['dsn'], 'doctrine://') && 0 !== strpos($configuration['transport']['dsn'], 'dbal://')) {
             return;
         }
 

--- a/src/Worker/AbstractWorker.php
+++ b/src/Worker/AbstractWorker.php
@@ -40,7 +40,6 @@ use Throwable;
 abstract class AbstractWorker implements WorkerInterface
 {
     protected array $options = [];
-    protected bool $shouldStop = false;
 
     private RunnerRegistryInterface $runnerRegistry;
     private TaskListInterface $failedTasks;
@@ -94,6 +93,7 @@ abstract class AbstractWorker implements WorkerInterface
         $fork = clone $this;
         $fork->options['isFork'] = true;
         $fork->options['forkedFrom'] = $this;
+        $fork->configuration = WorkerConfiguration::create();
 
         $this->dispatch(new WorkerForkedEvent($this, $fork));
 
@@ -173,7 +173,10 @@ abstract class AbstractWorker implements WorkerInterface
         return $this->options;
     }
 
-    protected function getConfiguration(): WorkerConfiguration
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfiguration(): WorkerConfiguration
     {
         return $this->configuration;
     }
@@ -284,7 +287,6 @@ abstract class AbstractWorker implements WorkerInterface
             'lastExecutedTask' => null,
             'sleepDurationDelay' => 1,
             'sleepUntilNextMinute' => false,
-            'shouldStop' => false,
             'shouldRetrieveTasksLazily' => false,
         ]);
 
@@ -295,7 +297,6 @@ abstract class AbstractWorker implements WorkerInterface
         $optionsResolver->setAllowedTypes('lastExecutedTask', [TaskInterface::class, 'null']);
         $optionsResolver->setAllowedTypes('sleepDurationDelay', 'int');
         $optionsResolver->setAllowedTypes('sleepUntilNextMinute', 'bool');
-        $optionsResolver->setAllowedTypes('shouldStop', 'bool');
         $optionsResolver->setAllowedTypes('shouldRetrieveTasksLazily', 'bool');
 
         $this->options = $optionsResolver->resolve($options);

--- a/src/Worker/Worker.php
+++ b/src/Worker/Worker.php
@@ -22,7 +22,9 @@ final class Worker extends AbstractWorker
     public function execute(array $options = [], TaskInterface ...$tasks): void
     {
         $this->run($options, function () use ($options, $tasks): void {
-            while (!$this->getOptions()['shouldStop']) {
+            $configuration = $this->getConfiguration();
+
+            while (!$configuration->shouldStop()) {
                 $toExecuteTasks = $this->getTasks($tasks);
                 if (0 === $toExecuteTasks->count() && !$this->getOptions()['sleepUntilNextMinute']) {
                     $this->stop();
@@ -67,8 +69,6 @@ final class Worker extends AbstractWorker
                 if ($this->getOptions()['sleepUntilNextMinute']) {
                     $this->sleep();
                     $this->execute($options);
-
-                    break;
                 }
             }
         });

--- a/src/Worker/WorkerConfiguration.php
+++ b/src/Worker/WorkerConfiguration.php
@@ -11,6 +11,10 @@ final class WorkerConfiguration
 {
     private bool $shouldStop;
 
+    private function __construct()
+    {
+    }
+
     public static function create(): self
     {
         $self = new self();

--- a/src/Worker/WorkerConfiguration.php
+++ b/src/Worker/WorkerConfiguration.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchedulerBundle\Worker;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class WorkerConfiguration
+{
+    private bool $shouldStop;
+
+    public static function create(): self
+    {
+        $self = new self();
+        $self->shouldStop = false;
+
+        return $self;
+    }
+
+    public function stop(): void
+    {
+        $this->shouldStop = true;
+    }
+
+    public function shouldStop(): bool
+    {
+        return $this->shouldStop;
+    }
+}

--- a/src/Worker/WorkerInterface.php
+++ b/src/Worker/WorkerInterface.php
@@ -96,4 +96,9 @@ interface WorkerInterface
      * @return array<string, array|string|bool|int|null|TaskInterface|WorkerInterface>
      */
     public function getOptions(): array;
+
+    /**
+     * Return the configuration of the worker currently used.
+     */
+    public function getConfiguration(): WorkerConfiguration;
 }

--- a/tests/DependencyInjection/SchedulerBundleExtensionTest.php
+++ b/tests/DependencyInjection/SchedulerBundleExtensionTest.php
@@ -710,7 +710,10 @@ final class SchedulerBundleExtensionTest extends TestCase
         self::assertSame(ChainedBuilder::class, $container->getDefinition(ChainedBuilder::class)->getClass());
         self::assertCount(2, $container->getDefinition(ChainedBuilder::class)->getArguments());
         self::assertInstanceOf(Reference::class, $container->getDefinition(ChainedBuilder::class)->getArgument(0));
+        self::assertSame(BuilderInterface::class, (string) $container->getDefinition(ChainedBuilder::class)->getArgument(0));
+        self::assertSame(ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $container->getDefinition(ChainedBuilder::class)->getArgument(0)->getInvalidBehavior());
         self::assertInstanceOf(TaggedIteratorArgument::class, $container->getDefinition(ChainedBuilder::class)->getArgument(1));
+        self::assertSame('scheduler.task_builder', $container->getDefinition(ChainedBuilder::class)->getArgument(1)->getTag());
         self::assertTrue($container->getDefinition(ChainedBuilder::class)->hasTag('scheduler.task_builder'));
         self::assertTrue($container->getDefinition(ChainedBuilder::class)->hasTag('container.preload'));
         self::assertSame(ChainedBuilder::class, $container->getDefinition(ChainedBuilder::class)->getTag('container.preload')[0]['class']);

--- a/tests/DependencyInjection/SchedulerBundleExtensionTest.php
+++ b/tests/DependencyInjection/SchedulerBundleExtensionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\SchedulerBundle\DependencyInjection;
 
+use Generator;
 use PHPUnit\Framework\TestCase;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
@@ -1213,13 +1214,16 @@ final class SchedulerBundleExtensionTest extends TestCase
         self::assertInstanceOf(Definition::class, $container->getDefinition(Scheduler::class)->getMethodCalls()[0][1][0]);
     }
 
-    public function testDoctrineBridgeIsConfigured(): void
+    /**
+     * @dataProvider provideDoctrineDsn
+     */
+    public function testDoctrineBridgeIsConfigured(string $dsn): void
     {
         $container = $this->getContainer([
             'path' => '/_foo',
             'timezone' => 'Europe/Paris',
             'transport' => [
-                'dsn' => 'doctrine://default',
+                'dsn' => $dsn,
             ],
             'tasks' => [],
             'lock_store' => null,
@@ -1588,6 +1592,15 @@ final class SchedulerBundleExtensionTest extends TestCase
         $extension = new SchedulerBundleExtension();
 
         self::assertInstanceOf(SchedulerBundleConfiguration::class, $extension->getConfiguration([], new ContainerBuilder()));
+    }
+
+    /**
+     * @return Generator<int, string>
+     */
+    public function provideDoctrineDsn(): Generator
+    {
+        yield 'Doctrine version' => ['doctrine://default'];
+        yield 'Dbal version' => ['dbal://default'];
     }
 
     /**

--- a/tests/DependencyInjection/SchedulerBundleExtensionTest.php
+++ b/tests/DependencyInjection/SchedulerBundleExtensionTest.php
@@ -1214,6 +1214,22 @@ final class SchedulerBundleExtensionTest extends TestCase
         self::assertInstanceOf(Definition::class, $container->getDefinition(Scheduler::class)->getMethodCalls()[0][1][0]);
     }
 
+    public function testDoctrineBridgeCannotBeConfiguredWithInvalidDsn(): void
+    {
+        $container = $this->getContainer([
+            'path' => '/_foo',
+            'timezone' => 'Europe/Paris',
+            'transport' => [
+                'dsn' => 'memory://batch',
+            ],
+            'tasks' => [],
+            'lock_store' => null,
+        ]);
+
+        self::assertFalse($container->hasDefinition(SchedulerTransportDoctrineSchemaSubscriber::class));
+        self::assertFalse($container->hasDefinition(DoctrineTransportFactory::class));
+    }
+
     /**
      * @dataProvider provideDoctrineDsn
      */
@@ -1595,7 +1611,7 @@ final class SchedulerBundleExtensionTest extends TestCase
     }
 
     /**
-     * @return Generator<int, string>
+     * @return Generator<array<int, string>>
      */
     public function provideDoctrineDsn(): Generator
     {

--- a/tests/DependencyInjection/SchedulerBundleExtensionTest.php
+++ b/tests/DependencyInjection/SchedulerBundleExtensionTest.php
@@ -666,6 +666,8 @@ final class SchedulerBundleExtensionTest extends TestCase
         self::assertTrue($container->getDefinition(AbstractTaskBuilder::class)->isAbstract());
         self::assertCount(1, $container->getDefinition(AbstractTaskBuilder::class)->getArguments());
         self::assertInstanceOf(Reference::class, $container->getDefinition(AbstractTaskBuilder::class)->getArgument(0));
+        self::assertSame(BuilderInterface::class, (string) $container->getDefinition(AbstractTaskBuilder::class)->getArgument(0));
+        self::assertSame(ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $container->getDefinition(AbstractTaskBuilder::class)->getArgument(0)->getInvalidBehavior());
         self::assertTrue($container->getDefinition(AbstractTaskBuilder::class)->hasTag('container.preload'));
         self::assertSame(AbstractTaskBuilder::class, $container->getDefinition(AbstractTaskBuilder::class)->getTag('container.preload')[0]['class']);
 
@@ -674,6 +676,8 @@ final class SchedulerBundleExtensionTest extends TestCase
         self::assertSame(CommandBuilder::class, $container->getDefinition(CommandBuilder::class)->getClass());
         self::assertCount(1, $container->getDefinition(CommandBuilder::class)->getArguments());
         self::assertInstanceOf(Reference::class, $container->getDefinition(CommandBuilder::class)->getArgument(0));
+        self::assertSame(BuilderInterface::class, (string) $container->getDefinition(CommandBuilder::class)->getArgument(0));
+        self::assertSame(ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $container->getDefinition(CommandBuilder::class)->getArgument(0)->getInvalidBehavior());
         self::assertTrue($container->getDefinition(CommandBuilder::class)->hasTag('scheduler.task_builder'));
         self::assertTrue($container->getDefinition(CommandBuilder::class)->hasTag('container.preload'));
         self::assertSame(CommandBuilder::class, $container->getDefinition(CommandBuilder::class)->getTag('container.preload')[0]['class']);
@@ -683,6 +687,8 @@ final class SchedulerBundleExtensionTest extends TestCase
         self::assertSame(HttpBuilder::class, $container->getDefinition(HttpBuilder::class)->getClass());
         self::assertCount(1, $container->getDefinition(HttpBuilder::class)->getArguments());
         self::assertInstanceOf(Reference::class, $container->getDefinition(HttpBuilder::class)->getArgument(0));
+        self::assertSame(BuilderInterface::class, (string) $container->getDefinition(HttpBuilder::class)->getArgument(0));
+        self::assertSame(ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $container->getDefinition(HttpBuilder::class)->getArgument(0)->getInvalidBehavior());
         self::assertTrue($container->getDefinition(HttpBuilder::class)->hasTag('scheduler.task_builder'));
         self::assertTrue($container->getDefinition(HttpBuilder::class)->hasTag('container.preload'));
         self::assertSame(HttpBuilder::class, $container->getDefinition(HttpBuilder::class)->getTag('container.preload')[0]['class']);
@@ -692,6 +698,8 @@ final class SchedulerBundleExtensionTest extends TestCase
         self::assertSame(NullBuilder::class, $container->getDefinition(NullBuilder::class)->getClass());
         self::assertCount(1, $container->getDefinition(NullBuilder::class)->getArguments());
         self::assertInstanceOf(Reference::class, $container->getDefinition(NullBuilder::class)->getArgument(0));
+        self::assertSame(BuilderInterface::class, (string) $container->getDefinition(NullBuilder::class)->getArgument(0));
+        self::assertSame(ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $container->getDefinition(NullBuilder::class)->getArgument(0)->getInvalidBehavior());
         self::assertTrue($container->getDefinition(NullBuilder::class)->hasTag('scheduler.task_builder'));
         self::assertTrue($container->getDefinition(NullBuilder::class)->hasTag('container.preload'));
         self::assertSame(NullBuilder::class, $container->getDefinition(NullBuilder::class)->getTag('container.preload')[0]['class']);
@@ -701,6 +709,8 @@ final class SchedulerBundleExtensionTest extends TestCase
         self::assertSame(ShellBuilder::class, $container->getDefinition(ShellBuilder::class)->getClass());
         self::assertCount(1, $container->getDefinition(ShellBuilder::class)->getArguments());
         self::assertInstanceOf(Reference::class, $container->getDefinition(ShellBuilder::class)->getArgument(0));
+        self::assertSame(BuilderInterface::class, (string) $container->getDefinition(ShellBuilder::class)->getArgument(0));
+        self::assertSame(ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $container->getDefinition(ShellBuilder::class)->getArgument(0)->getInvalidBehavior());
         self::assertTrue($container->getDefinition(ShellBuilder::class)->hasTag('scheduler.task_builder'));
         self::assertTrue($container->getDefinition(ShellBuilder::class)->hasTag('container.preload'));
         self::assertSame(ShellBuilder::class, $container->getDefinition(ShellBuilder::class)->getTag('container.preload')[0]['class']);
@@ -712,8 +722,8 @@ final class SchedulerBundleExtensionTest extends TestCase
         self::assertInstanceOf(Reference::class, $container->getDefinition(ChainedBuilder::class)->getArgument(0));
         self::assertSame(BuilderInterface::class, (string) $container->getDefinition(ChainedBuilder::class)->getArgument(0));
         self::assertSame(ContainerInterface::EXCEPTION_ON_INVALID_REFERENCE, $container->getDefinition(ChainedBuilder::class)->getArgument(0)->getInvalidBehavior());
-        self::assertInstanceOf(TaggedIteratorArgument::class, $container->getDefinition(ChainedBuilder::class)->getArgument(1));
-        self::assertSame('scheduler.task_builder', $container->getDefinition(ChainedBuilder::class)->getArgument(1)->getTag());
+        self::assertInstanceOf(TaggedIteratorArgument::class, $container->getDefinition(ChainedBuilder::class)->getArgument('$builders'));
+        self::assertSame('scheduler.task_builder', $container->getDefinition(ChainedBuilder::class)->getArgument('$builders')->getTag());
         self::assertTrue($container->getDefinition(ChainedBuilder::class)->hasTag('scheduler.task_builder'));
         self::assertTrue($container->getDefinition(ChainedBuilder::class)->hasTag('container.preload'));
         self::assertSame(ChainedBuilder::class, $container->getDefinition(ChainedBuilder::class)->getTag('container.preload')[0]['class']);

--- a/tests/EventListener/ProbeStateSubscriberTest.php
+++ b/tests/EventListener/ProbeStateSubscriberTest.php
@@ -26,8 +26,11 @@ final class ProbeStateSubscriberTest extends TestCase
     public function testEventsAreCorrectlyListened(): void
     {
         self::assertArrayHasKey(KernelEvents::REQUEST, ProbeStateSubscriber::getSubscribedEvents());
-        self::assertContainsEquals('onKernelRequest', ProbeStateSubscriber::getSubscribedEvents()[KernelEvents::REQUEST][0]);
-        self::assertContainsEquals(50, ProbeStateSubscriber::getSubscribedEvents()[KernelEvents::REQUEST][0]);
+        self::assertIsArray(ProbeStateSubscriber::getSubscribedEvents()[KernelEvents::REQUEST][0]);
+        self::assertArrayHasKey(0, ProbeStateSubscriber::getSubscribedEvents()[KernelEvents::REQUEST][0]);
+        self::assertArrayHasKey(1, ProbeStateSubscriber::getSubscribedEvents()[KernelEvents::REQUEST][0]);
+        self::assertSame('onKernelRequest', ProbeStateSubscriber::getSubscribedEvents()[KernelEvents::REQUEST][0][0]);
+        self::assertSame(50, ProbeStateSubscriber::getSubscribedEvents()[KernelEvents::REQUEST][0][1]);
     }
 
     /**

--- a/tests/EventListener/StopWorkerOnSignalSubscriberTest.php
+++ b/tests/EventListener/StopWorkerOnSignalSubscriberTest.php
@@ -20,12 +20,15 @@ final class StopWorkerOnSignalSubscriberTest extends TestCase
     public function testEventsAreSubscribed(): void
     {
         self::assertArrayHasKey(WorkerStartedEvent::class, StopWorkerOnSignalSubscriber::getSubscribedEvents());
+        self::assertIsArray(StopWorkerOnSignalSubscriber::getSubscribedEvents()[WorkerStartedEvent::class]);
         self::assertContains(100, StopWorkerOnSignalSubscriber::getSubscribedEvents()[WorkerStartedEvent::class]);
         self::assertContains('onWorkerStarted', StopWorkerOnSignalSubscriber::getSubscribedEvents()[WorkerStartedEvent::class]);
         self::assertArrayHasKey(WorkerRunningEvent::class, StopWorkerOnSignalSubscriber::getSubscribedEvents());
+        self::assertIsArray(StopWorkerOnSignalSubscriber::getSubscribedEvents()[WorkerRunningEvent::class]);
         self::assertContains(100, StopWorkerOnSignalSubscriber::getSubscribedEvents()[WorkerRunningEvent::class]);
         self::assertContains('onWorkerRunning', StopWorkerOnSignalSubscriber::getSubscribedEvents()[WorkerRunningEvent::class]);
         self::assertArrayHasKey(WorkerSleepingEvent::class, StopWorkerOnSignalSubscriber::getSubscribedEvents());
+        self::assertIsArray(StopWorkerOnSignalSubscriber::getSubscribedEvents()[WorkerSleepingEvent::class]);
         self::assertContains(100, StopWorkerOnSignalSubscriber::getSubscribedEvents()[WorkerSleepingEvent::class]);
         self::assertContains('onWorkerSleeping', StopWorkerOnSignalSubscriber::getSubscribedEvents()[WorkerSleepingEvent::class]);
     }

--- a/tests/EventListener/TaskLoggerSubscriberTest.php
+++ b/tests/EventListener/TaskLoggerSubscriberTest.php
@@ -23,22 +23,27 @@ final class TaskLoggerSubscriberTest extends TestCase
     public function testEventsAreSubscribed(): void
     {
         self::assertArrayHasKey(TaskScheduledEvent::class, TaskLoggerSubscriber::getSubscribedEvents());
+        self::assertIsArray(TaskLoggerSubscriber::getSubscribedEvents()[TaskExecutedEvent::class]);
         self::assertContains('onTask', TaskLoggerSubscriber::getSubscribedEvents()[TaskExecutedEvent::class]);
         self::assertContains(-255, TaskLoggerSubscriber::getSubscribedEvents()[TaskExecutedEvent::class]);
 
         self::assertArrayHasKey(TaskFailedEvent::class, TaskLoggerSubscriber::getSubscribedEvents());
+        self::assertIsArray(TaskLoggerSubscriber::getSubscribedEvents()[TaskFailedEvent::class]);
         self::assertContains('onTask', TaskLoggerSubscriber::getSubscribedEvents()[TaskFailedEvent::class]);
         self::assertContains(-255, TaskLoggerSubscriber::getSubscribedEvents()[TaskFailedEvent::class]);
 
         self::assertArrayHasKey(TaskQueued::class, TaskLoggerSubscriber::getSubscribedEvents());
+        self::assertIsArray(TaskLoggerSubscriber::getSubscribedEvents()[TaskQueued::class]);
         self::assertContains('onTask', TaskLoggerSubscriber::getSubscribedEvents()[TaskQueued::class]);
         self::assertContains(-255, TaskLoggerSubscriber::getSubscribedEvents()[TaskQueued::class]);
 
         self::assertArrayHasKey(TaskScheduledEvent::class, TaskLoggerSubscriber::getSubscribedEvents());
+        self::assertIsArray(TaskLoggerSubscriber::getSubscribedEvents()[TaskScheduledEvent::class]);
         self::assertContains('onTask', TaskLoggerSubscriber::getSubscribedEvents()[TaskScheduledEvent::class]);
         self::assertContains(-255, TaskLoggerSubscriber::getSubscribedEvents()[TaskScheduledEvent::class]);
 
         self::assertArrayHasKey(TaskUnscheduledEvent::class, TaskLoggerSubscriber::getSubscribedEvents());
+        self::assertIsArray(TaskLoggerSubscriber::getSubscribedEvents()[TaskUnscheduledEvent::class]);
         self::assertContains('onTask', TaskLoggerSubscriber::getSubscribedEvents()[TaskUnscheduledEvent::class]);
         self::assertContains(-255, TaskLoggerSubscriber::getSubscribedEvents()[TaskUnscheduledEvent::class]);
     }

--- a/tests/EventListener/TaskSubscriberTest.php
+++ b/tests/EventListener/TaskSubscriberTest.php
@@ -33,6 +33,7 @@ final class TaskSubscriberTest extends TestCase
     public function testEventsAreCorrectlyListened(): void
     {
         self::assertArrayHasKey(KernelEvents::REQUEST, TaskSubscriber::getSubscribedEvents());
+        self::assertIsArray(TaskSubscriber::getSubscribedEvents()[KernelEvents::REQUEST][0]);
         self::assertContainsEquals('onKernelRequest', TaskSubscriber::getSubscribedEvents()[KernelEvents::REQUEST][0]);
         self::assertContainsEquals(50, TaskSubscriber::getSubscribedEvents()[KernelEvents::REQUEST][0]);
     }

--- a/tests/Transport/Configuration/FailOverConfigurationTest.php
+++ b/tests/Transport/Configuration/FailOverConfigurationTest.php
@@ -140,7 +140,10 @@ final class FailOverConfigurationTest extends TestCase
         ]);
 
         $failOverConfiguration->set('foo', 'bar');
-        self::assertArrayHasKey('foo', $failOverConfiguration->getOptions());
-        self::assertSame('bar', $failOverConfiguration->getOptions()['foo']);
+
+        $options = $failOverConfiguration->getOptions();
+        self::assertIsArray($options);
+        self::assertArrayHasKey('foo', $options);
+        self::assertSame('bar', $options['foo']);
     }
 }

--- a/tests/Transport/Configuration/InMemoryConfigurationTest.php
+++ b/tests/Transport/Configuration/InMemoryConfigurationTest.php
@@ -18,6 +18,7 @@ final class InMemoryConfigurationTest extends TestCase
 
         $inMemoryConfiguration->set('foo', 'bar');
 
+        self::assertIsArray($inMemoryConfiguration->getOptions());
         self::assertArrayHasKey('foo', $inMemoryConfiguration->getOptions());
         self::assertSame('bar', $inMemoryConfiguration->get('foo'));
     }
@@ -28,11 +29,13 @@ final class InMemoryConfigurationTest extends TestCase
 
         $inMemoryConfiguration->set('foo', 'bar');
 
+        self::assertIsArray($inMemoryConfiguration->getOptions());
         self::assertArrayHasKey('foo', $inMemoryConfiguration->getOptions());
         self::assertSame('bar', $inMemoryConfiguration->get('foo'));
 
         $inMemoryConfiguration->update('foo', 'foo_new');
 
+        self::assertIsArray($inMemoryConfiguration->getOptions());
         self::assertArrayHasKey('foo', $inMemoryConfiguration->getOptions());
         self::assertSame('foo_new', $inMemoryConfiguration->get('foo'));
     }
@@ -43,11 +46,13 @@ final class InMemoryConfigurationTest extends TestCase
 
         $inMemoryConfiguration->set('foo', 'bar');
 
+        self::assertIsArray($inMemoryConfiguration->getOptions());
         self::assertArrayHasKey('foo', $inMemoryConfiguration->getOptions());
         self::assertSame('bar', $inMemoryConfiguration->get('foo'));
 
         $inMemoryConfiguration->remove('foo');
 
+        self::assertIsArray($inMemoryConfiguration->getOptions());
         self::assertArrayNotHasKey('foo', $inMemoryConfiguration->getOptions());
         self::assertNull($inMemoryConfiguration->get('foo'));
     }

--- a/tests/Worker/WorkerConfigurationTest.php
+++ b/tests/Worker/WorkerConfigurationTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SchedulerBundle\Worker;
+
+use PHPUnit\Framework\TestCase;
+use SchedulerBundle\Worker\WorkerConfiguration;
+
+/**
+ * @author Guillaume Loulier <contact@guillaumeloulier.fr>
+ */
+final class WorkerConfigurationTest extends TestCase
+{
+    public function testConfigurationCanBeCreated(): void
+    {
+        $configuration = WorkerConfiguration::create();
+        self::assertFalse($configuration->shouldStop());
+
+        $configuration->stop();
+        self::assertTrue($configuration->shouldStop());
+    }
+}


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | 7.4
| Bundle version?  | 0.6.1
| New feature?     | no
| Bug fix?         | yes

# Context

Since `0.5.0`, the worker cannot be stopped once it enter the `sleeping` phase.

# Stack trace

The worker use the `shouldStop` option to decide if it should stop or not, regarding the debug phase, it seems that the option is reset to `false` but rollback to `true` at the next iteration. 

This behaviour could be a result of PHP usage of arrays, using an attribute is recommended.

# Additional informations

<!-- Content -->
