### PR TITLE
Fix PHP 8.1 deprecation

### DIFF
--- a/src/Scheduler.php
+++ b/src/Scheduler.php
@@ -302,8 +302,9 @@ final class Scheduler implements SchedulerInterface
     private function getSynchronizedCurrentDate(): DateTimeImmutable
     {
         $dateInterval = $this->initializationDate->diff(new DateTimeImmutable('now', $this->timezone));
-        if ($dateInterval->f % self::MIN_SYNCHRONIZATION_DELAY < 0 || $dateInterval->f % self::MAX_SYNCHRONIZATION_DELAY > 0) {
-            throw new RuntimeException(sprintf('The scheduler is not synchronized with the current clock, current delay: %d microseconds, allowed range: [%s, %s]', $dateInterval->f, self::MIN_SYNCHRONIZATION_DELAY, self::MAX_SYNCHRONIZATION_DELAY));
+        $microSecondsInterval = (int) $dateInterval->f;
+        if ($microSecondsInterval % self::MIN_SYNCHRONIZATION_DELAY < 0 || $microSecondsInterval % self::MAX_SYNCHRONIZATION_DELAY > 0) {
+            throw new RuntimeException(sprintf('The scheduler is not synchronized with the current clock, current delay: %d microseconds, allowed range: [%s, %s]', $microSecondsInterval, self::MIN_SYNCHRONIZATION_DELAY, self::MAX_SYNCHRONIZATION_DELAY));
         }
 
         return $this->initializationDate->add($dateInterval);


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | 8.1
| Bundle version?  | 0.7.1
| Symfony version? | N/A
| New feature?     | no
| Bug fix?         | yes
| Discussion?      | N/A

# Context

Running with PHP 8.1 (I know, it's not officially supported, but still :)), I get the following deprecation:

> Implicit conversion from float 0.002448 to int loses precision

# Expected behaviour
No deprecation

# Stack trace

Scheduler.php L305

# Additional informations

N/A
