### PR TITLE
feat(expression): add ExactExpressionBuilder

### DIFF
--- a/src/Expression/ExactExpressionBuilder.php
+++ b/src/Expression/ExactExpressionBuilder.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SchedulerBundle\Expression;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use SchedulerBundle\Exception\InvalidArgumentException;
+use function sprintf;
+use function strtotime;
+
+/**
+ * @author Jérémy Reynaud <info@babeuloula.fr>
+ */
+final class ExactExpressionBuilder implements ExpressionBuilderInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function build(string $expression, string $timezone = 'UTC'): Expression
+    {
+        $date = DateTimeImmutable::createFromFormat('U', (string) strtotime($expression));
+        if (false === $date) {
+            throw new InvalidArgumentException(sprintf('The "%s" expression cannot be used to create a date', $expression));
+        }
+
+        $date = $date->setTimezone(new DateTimeZone($timezone));
+
+        $expression = new Expression();
+        $expression->setExpression(sprintf(
+            '%d %s %s %s *',
+            $date->format('i'),
+            $date->format('G'),
+            $date->format('j'),
+            $date->format('n')
+        ));
+
+        return $expression;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function support(string $expression): bool
+    {
+        return false !== strtotime($expression);
+    }
+}

--- a/tests/Expression/ExactExpressionBuilderTest.php
+++ b/tests/Expression/ExactExpressionBuilderTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\SchedulerBundle\Expression;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Generator;
+use PHPUnit\Framework\TestCase;
+use SchedulerBundle\Exception\InvalidArgumentException;
+use SchedulerBundle\Expression\ExactExpressionBuilder;
+use Throwable;
+
+/**
+ * @author Jérémy Reynaud <info@babeuloula.fr>
+ */
+final class ExactExpressionBuilderTest extends TestCase
+{
+    public function testBuilderSupport(): void
+    {
+        $exactExpressionBuilder = new ExactExpressionBuilder();
+
+        self::assertFalse($exactExpressionBuilder->support('* * * * *'));
+        self::assertTrue($exactExpressionBuilder->support('next monday'));
+    }
+
+    /**
+     * @throws Throwable {@see ExpressionBuilderInterface::build()}
+     */
+    public function testBuilderCannotBuildWithInvalidDate(): void
+    {
+        $exactExpressionBuilder = new ExactExpressionBuilder();
+
+        self::expectException(InvalidArgumentException::class);
+        self::expectExceptionMessage('The "foo" expression cannot be used to create a date');
+        self::expectExceptionCode(0);
+        $exactExpressionBuilder->build('foo');
+    }
+
+    /**
+     * @dataProvider provideExpression
+     *
+     * @throws Throwable {@see ExpressionBuilderInterface::build()}
+     */
+    public function testBuilderCanBuild(string $expression, string $endExpression): void
+    {
+        $exactExpressionBuilder = new ExactExpressionBuilder();
+        $finalExpression = $exactExpressionBuilder->build($expression);
+
+        self::assertSame($finalExpression->getExpression(), $endExpression);
+    }
+
+    /**
+     * @dataProvider provideExpressionWithTimezone
+     *
+     * @throws Throwable {@see ExpressionBuilderInterface::build()}
+     */
+    public function testBuilderCanBuildWithTimezone(string $expression, string $endExpression, string $timezone): void
+    {
+        $exactExpressionBuilder = new ExactExpressionBuilder();
+        $finalExpression = $exactExpressionBuilder->build($expression, $timezone);
+
+        self::assertSame($finalExpression->getExpression(), $endExpression);
+    }
+
+    /**
+     * @return Generator<array<int, string>>
+     */
+    public function provideExpression(): Generator
+    {
+        yield ['first monday of January 1980 10:00', '0 10 7 1 *'];
+        yield ['last monday of July 1970 10:00', '0 10 27 7 *'];
+        yield ['first day of January 2008', '0 0 1 1 *'];
+        yield ['12/22/78', '0 0 22 12 *'];
+        yield ['10/Oct/2000:13:55:36 -0700', '55 20 10 10 *'];
+    }
+
+    /**
+     * @return Generator<array<int, string>>
+     */
+    public function provideExpressionWithTimezone(): Generator
+    {
+        yield ['first monday of January 1980 10:00', '0 10 7 1 *', 'UTC'];
+        yield ['last monday of July 1970 10:00', '0 10 27 7 *', 'UTC'];
+        yield ['first day of January 2008', '0 0 1 1 *', 'UTC'];
+        yield ['12/22/78', '0 0 22 12 *', 'UTC'];
+        yield ['10/Oct/2000:13:55:36 -0700', '55 20 10 10 *', 'UTC'];
+
+        $datetime = new DateTimeImmutable();
+        $datetime = $datetime->setTimezone(new DateTimeZone('Europe/Paris'));
+        $datetime = $datetime->modify("+1 minute");
+        yield [
+            $datetime->format(DateTimeImmutable::RFC3339),
+            sprintf(
+                '%d %s %s %s *',
+                $datetime->format('i'),
+                $datetime->format('G'),
+                $datetime->format('j'),
+                $datetime->format('n')
+            ),
+            'Europe/Paris',
+        ];
+    }
+}


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | 7.4
| Bundle version?  | 0.7.1
| Symfony version? | >= 5.4
| New feature?     | yes
| Bug fix?         | no
| Discussion?      | # ...

# Context

`FluentExpressionBuilder` can create false next run execution date. Example : 
- _40 18 20 3 0_ propose a next run at _2022-03-06 18:40_

In case you want to create an exact expression, you can use `ExactExpressionBuilder` and you got an expression like this _40 18 20 3 *_ and propose a next run at _2022-03-20 18:40_.

@Guikingone I've made a new ExpressionBuilder to keep the backward compatibilty.
