### PR TITLE
feat(tasks): add option deleteAfterExecute

### DIFF
--- a/src/Middleware/SingleRunTaskMiddleware.php
+++ b/src/Middleware/SingleRunTaskMiddleware.php
@@ -41,6 +41,12 @@ final class SingleRunTaskMiddleware implements PostExecutionMiddlewareInterface,
             return;
         }
 
+        if ($task->isDeleteAfterExecute()) {
+            $this->scheduler->unschedule($task->getName());
+
+            return;
+        }
+
         $this->scheduler->pause($task->getName());
     }
 

--- a/src/Task/AbstractTask.php
+++ b/src/Task/AbstractTask.php
@@ -87,6 +87,7 @@ abstract class AbstractTask implements TaskInterface
             'queued' => false,
             'scheduled_at' => null,
             'single_run' => false,
+            'delete_after_execute' => false,
             'state' => TaskInterface::ENABLED,
             'execution_state' => null,
             'tags' => [],
@@ -128,6 +129,7 @@ abstract class AbstractTask implements TaskInterface
         $optionsResolver->setAllowedTypes('queued', 'bool');
         $optionsResolver->setAllowedTypes('scheduled_at', [DateTimeImmutable::class, 'null']);
         $optionsResolver->setAllowedTypes('single_run', 'bool');
+        $optionsResolver->setAllowedTypes('delete_after_execute', 'bool');
         $optionsResolver->setAllowedTypes('state', 'string');
         $optionsResolver->setAllowedTypes('execution_state', ['string', 'null']);
         $optionsResolver->setAllowedTypes('tags', 'string[]');
@@ -168,6 +170,7 @@ abstract class AbstractTask implements TaskInterface
         $optionsResolver->setInfo('output_to_store', 'Define if the output of the task must be stored');
         $optionsResolver->setInfo('scheduled_at', 'Define the date where the task has been scheduled');
         $optionsResolver->setInfo('single_run', 'Define if the task must run only once, if so, the task is unscheduled from the scheduler once executed');
+        $optionsResolver->setInfo('delete_after_execute', 'Define if the task will be deleted from the scheduler after execution (works only with single_run at true)');
         $optionsResolver->setInfo('state', 'Define the state of the task, mainly used by the worker and transports to execute enabled tasks');
         $optionsResolver->setInfo('execution_state', '[INTERNAL] Define the state of the task during the execution phase, mainly used by the worker');
         $optionsResolver->setInfo('queued', 'Define if the task need to be dispatched to a "symfony/messenger" queue');
@@ -716,6 +719,18 @@ abstract class AbstractTask implements TaskInterface
     public function setSingleRun(bool $singleRun): TaskInterface
     {
         $this->options['single_run'] = $singleRun;
+
+        return $this;
+    }
+
+    public function isDeleteAfterExecute(): bool
+    {
+        return is_bool($this->options['delete_after_execute']) && $this->options['delete_after_execute'];
+    }
+
+    public function setDeleteAfterExecute(bool $deleteAfterExecute): TaskInterface
+    {
+        $this->options['delete_after_execute'] = $deleteAfterExecute;
 
         return $this;
     }

--- a/src/Task/TaskInterface.php
+++ b/src/Task/TaskInterface.php
@@ -309,6 +309,10 @@ interface TaskInterface
 
     public function setSingleRun(bool $singleRun): self;
 
+    public function isDeleteAfterExecute(): bool;
+
+    public function setDeleteAfterExecute(bool $deleteAfterExecute): self;
+
     /**
      * @return array<int, string>
      */

--- a/src/Transport/FilesystemTransport.php
+++ b/src/Transport/FilesystemTransport.php
@@ -54,6 +54,7 @@ final class FilesystemTransport extends AbstractTransport
 
         $finder = new Finder();
 
+        $this->filesystem->mkdir($this->options['path']);
         $finder->files()->in($this->options['path'])->name('*.json');
         foreach ($finder as $singleFinder) {
             $tasks->add($this->get(strtr($singleFinder->getFilename(), ['.json' => ''])));

--- a/tests/Middleware/SingleRunTaskMiddlewareTest.php
+++ b/tests/Middleware/SingleRunTaskMiddlewareTest.php
@@ -40,6 +40,7 @@ final class SingleRunTaskMiddlewareTest extends TestCase
 
         $scheduler = $this->createMock(SchedulerInterface::class);
         $scheduler->expects(self::never())->method('pause');
+        $scheduler->expects(self::never())->method('unschedule');
 
         $singleRunTaskMiddleware = new SingleRunTaskMiddleware($scheduler, $logger);
         $singleRunTaskMiddleware->postExecute(new NullTask('foo', [
@@ -59,6 +60,7 @@ final class SingleRunTaskMiddlewareTest extends TestCase
 
         $scheduler = $this->createMock(SchedulerInterface::class);
         $scheduler->expects(self::never())->method('pause');
+        $scheduler->expects(self::never())->method('unschedule');
 
         $singleRunTaskMiddleware = new SingleRunTaskMiddleware($scheduler, $logger);
         $singleRunTaskMiddleware->postExecute(new NullTask('foo', [
@@ -79,6 +81,7 @@ final class SingleRunTaskMiddlewareTest extends TestCase
 
         $scheduler = $this->createMock(SchedulerInterface::class);
         $scheduler->expects(self::never())->method('pause');
+        $scheduler->expects(self::never())->method('unschedule');
 
         $singleRunTaskMiddleware = new SingleRunTaskMiddleware($scheduler);
         $singleRunTaskMiddleware->postExecute($task, $worker);
@@ -97,6 +100,27 @@ final class SingleRunTaskMiddlewareTest extends TestCase
 
         $scheduler = $this->createMock(SchedulerInterface::class);
         $scheduler->expects(self::once())->method('pause')->with(self::equalTo('foo'));
+        $scheduler->expects(self::never())->method('unschedule');
+
+        $singleRunTaskMiddleware = new SingleRunTaskMiddleware($scheduler);
+        $singleRunTaskMiddleware->postExecute($task, $worker);
+    }
+
+    /**
+     * @throws Throwable {@see PostExecutionMiddlewareInterface::postExecute()}
+     */
+    public function testMiddlewareCanHandleSingleRunAndDeleteAfterExecuteTask(): void
+    {
+        $worker = $this->createMock(WorkerInterface::class);
+
+        $task = $this->createMock(TaskInterface::class);
+        $task->expects(self::once())->method('getName')->willReturn('foo');
+        $task->expects(self::once())->method('isSingleRun')->willReturn(true);
+        $task->expects(self::once())->method('isDeleteAfterExecute')->willReturn(true);
+
+        $scheduler = $this->createMock(SchedulerInterface::class);
+        $scheduler->expects(self::never())->method('pause');
+        $scheduler->expects(self::once())->method('unschedule')->with(self::equalTo('foo'));
 
         $singleRunTaskMiddleware = new SingleRunTaskMiddleware($scheduler);
         $singleRunTaskMiddleware->postExecute($task, $worker);

--- a/tests/Middleware/SingleRunTaskMiddlewareTest.php
+++ b/tests/Middleware/SingleRunTaskMiddlewareTest.php
@@ -75,16 +75,14 @@ final class SingleRunTaskMiddlewareTest extends TestCase
     {
         $worker = $this->createMock(WorkerInterface::class);
 
-        $task = $this->createMock(TaskInterface::class);
-        $task->expects(self::never())->method('getName');
-        $task->expects(self::once())->method('isSingleRun')->willReturn(false);
-
         $scheduler = $this->createMock(SchedulerInterface::class);
         $scheduler->expects(self::never())->method('pause');
         $scheduler->expects(self::never())->method('unschedule');
 
         $singleRunTaskMiddleware = new SingleRunTaskMiddleware($scheduler);
-        $singleRunTaskMiddleware->postExecute($task, $worker);
+        $singleRunTaskMiddleware->postExecute(new NullTask('foo', [
+            'single_run' => false,
+        ]), $worker);
     }
 
     /**
@@ -94,35 +92,67 @@ final class SingleRunTaskMiddlewareTest extends TestCase
     {
         $worker = $this->createMock(WorkerInterface::class);
 
-        $task = $this->createMock(TaskInterface::class);
-        $task->expects(self::once())->method('getName')->willReturn('foo');
-        $task->expects(self::once())->method('isSingleRun')->willReturn(true);
-
         $scheduler = $this->createMock(SchedulerInterface::class);
         $scheduler->expects(self::once())->method('pause')->with(self::equalTo('foo'));
         $scheduler->expects(self::never())->method('unschedule');
 
         $singleRunTaskMiddleware = new SingleRunTaskMiddleware($scheduler);
-        $singleRunTaskMiddleware->postExecute($task, $worker);
+        $singleRunTaskMiddleware->postExecute(new NullTask('foo', [
+            'single_run' => true,
+        ]), $worker);
     }
 
     /**
      * @throws Throwable {@see PostExecutionMiddlewareInterface::postExecute()}
      */
-    public function testMiddlewareCanHandleSingleRunAndDeleteAfterExecuteTask(): void
+    public function testMiddlewareCanHandleSingleRunTrueAndDeleteAfterExecuteTrueTask(): void
     {
         $worker = $this->createMock(WorkerInterface::class);
-
-        $task = $this->createMock(TaskInterface::class);
-        $task->expects(self::once())->method('getName')->willReturn('foo');
-        $task->expects(self::once())->method('isSingleRun')->willReturn(true);
-        $task->expects(self::once())->method('isDeleteAfterExecute')->willReturn(true);
 
         $scheduler = $this->createMock(SchedulerInterface::class);
         $scheduler->expects(self::never())->method('pause');
         $scheduler->expects(self::once())->method('unschedule')->with(self::equalTo('foo'));
 
         $singleRunTaskMiddleware = new SingleRunTaskMiddleware($scheduler);
-        $singleRunTaskMiddleware->postExecute($task, $worker);
+        $singleRunTaskMiddleware->postExecute(new NullTask('foo', [
+            'single_run' => true,
+            'delete_after_execute' => true,
+        ]), $worker);
+    }
+
+    /**
+     * @throws Throwable {@see PostExecutionMiddlewareInterface::postExecute()}
+     */
+    public function testMiddlewareCanHandleSingleRunFalseAndDeleteAfterExecuteFalseTask(): void
+    {
+        $worker = $this->createMock(WorkerInterface::class);
+
+        $scheduler = $this->createMock(SchedulerInterface::class);
+        $scheduler->expects(self::never())->method('pause');
+        $scheduler->expects(self::never())->method('unschedule');
+
+        $singleRunTaskMiddleware = new SingleRunTaskMiddleware($scheduler);
+        $singleRunTaskMiddleware->postExecute(new NullTask('foo', [
+            'single_run' => false,
+            'delete_after_execute' => false,
+        ]), $worker);
+    }
+
+    /**
+     * @throws Throwable {@see PostExecutionMiddlewareInterface::postExecute()}
+     */
+    public function testMiddlewareCanHandleSingleRunFalseAndDeleteAfterExecuteTrueTask(): void
+    {
+        $worker = $this->createMock(WorkerInterface::class);
+
+        $scheduler = $this->createMock(SchedulerInterface::class);
+        $scheduler->expects(self::never())->method('pause');
+        $scheduler->expects(self::never())->method('unschedule');
+
+        $singleRunTaskMiddleware = new SingleRunTaskMiddleware($scheduler);
+        $singleRunTaskMiddleware->postExecute(new NullTask('foo', [
+            'single_run' => false,
+            'delete_after_execute' => true,
+        ]), $worker);
     }
 }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | 8.0
| Bundle version?  | 0.8.1
| Symfony version? | 6.0.4
| New feature?     | yes
| Bug fix?         | yes
| Discussion?      | no

# Context

When we create a task with `singleRun` option at `true`, it's not necessary to keep outdated tasks on the scheduler. And if we use the DoctrineTransport, the database will growup and it's useless.

With the new option `deleteAfterExecute` at `true` combine with `singleRun` at `true` also, the task will be unschedule and remove from the list.

# Additional informations

And I also fix the folder creation when we use the FilesystemTransport for the first time. The folder was not created automatically.
