### PR TITLE
refactor(command): fix $defaultName usage deprecation

### DIFF
--- a/src/Command/ConsumeTasksCommand.php
+++ b/src/Command/ConsumeTasksCommand.php
@@ -38,11 +38,6 @@ final class ConsumeTasksCommand extends Command
 {
     private LoggerInterface $logger;
 
-    /**
-     * @var string|null
-     */
-    protected static $defaultName = 'scheduler:consume';
-
     public function __construct(
         private SchedulerInterface $scheduler,
         private WorkerInterface $worker,
@@ -60,6 +55,7 @@ final class ConsumeTasksCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('scheduler:consume')
             ->setDescription('Consumes due tasks')
             ->setDefinition([
                 new InputOption('limit', 'l', InputOption::VALUE_REQUIRED, 'Limit the number of tasks consumed'),

--- a/src/Command/DebugConfigurationCommand.php
+++ b/src/Command/DebugConfigurationCommand.php
@@ -17,8 +17,6 @@ use function sprintf;
  */
 final class DebugConfigurationCommand extends Command
 {
-    protected static $defaultName = 'scheduler:debug:configuration';
-
     public function __construct(private ConfigurationInterface $configuration)
     {
         parent::__construct();
@@ -30,6 +28,7 @@ final class DebugConfigurationCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('scheduler:debug:configuration')
             ->setDescription(description: 'Display the current transport configuration keys and values')
             ->setHelp(
                 help:

--- a/src/Command/DebugMiddlewareCommand.php
+++ b/src/Command/DebugMiddlewareCommand.php
@@ -27,11 +27,6 @@ use function sprintf;
  */
 final class DebugMiddlewareCommand extends Command
 {
-    /**
-     * @var string|null
-     */
-    protected static $defaultName = 'scheduler:debug:middleware';
-
     public function __construct(
         private SchedulerMiddlewareStackInterface $schedulerMiddlewareStack,
         private WorkerMiddlewareStackInterface $workerMiddlewareStack
@@ -45,6 +40,7 @@ final class DebugMiddlewareCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('scheduler:debug:middleware')
             ->setDescription('Display the registered middlewares')
         ;
     }

--- a/src/Command/DebugProbeCommand.php
+++ b/src/Command/DebugProbeCommand.php
@@ -23,11 +23,6 @@ use function sprintf;
  */
 final class DebugProbeCommand extends Command
 {
-    /**
-     * @var string|null
-     */
-    protected static $defaultName = 'scheduler:debug:probe';
-
     public function __construct(
         private ProbeInterface $probe,
         private SchedulerInterface $scheduler
@@ -41,6 +36,7 @@ final class DebugProbeCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('scheduler:debug:probe')
             ->setDescription('Display the current probe state and the external probes state (if defined)')
             ->setDefinition([
                 new InputOption('external', null, InputOption::VALUE_NONE, 'Define if the external probes state must be displayed'),

--- a/src/Command/ExecuteExternalProbeCommand.php
+++ b/src/Command/ExecuteExternalProbeCommand.php
@@ -22,11 +22,6 @@ use function sprintf;
  */
 final class ExecuteExternalProbeCommand extends Command
 {
-    /**
-     * @var string|null
-     */
-    protected static $defaultName = 'scheduler:execute:external-probe';
-
     public function __construct(
         private SchedulerInterface $scheduler,
         private WorkerInterface $worker
@@ -40,6 +35,7 @@ final class ExecuteExternalProbeCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('scheduler:execute:external-probe')
             ->setDescription('Execute the external probes')
         ;
     }

--- a/src/Command/ExecuteTaskCommand.php
+++ b/src/Command/ExecuteTaskCommand.php
@@ -38,11 +38,6 @@ final class ExecuteTaskCommand extends Command
 {
     private LoggerInterface $logger;
 
-    /**
-     * @var string|null
-     */
-    protected static $defaultName = 'scheduler:execute';
-
     public function __construct(
         private EventDispatcherInterface $eventDispatcher,
         private SchedulerInterface $scheduler,
@@ -60,6 +55,7 @@ final class ExecuteTaskCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('scheduler:execute')
             ->setDescription('Execute tasks (due or not) depending on filters')
             ->setDefinition([
                 new InputOption('due', 'd', InputOption::VALUE_NONE, 'Define if the filters must be applied on due tasks'),

--- a/src/Command/ListFailedTasksCommand.php
+++ b/src/Command/ListFailedTasksCommand.php
@@ -20,11 +20,6 @@ use const DATE_ATOM;
  */
 final class ListFailedTasksCommand extends Command
 {
-    /**
-     * @var string|null
-     */
-    protected static $defaultName = 'scheduler:list:failed';
-
     public function __construct(private WorkerInterface $worker)
     {
         parent::__construct();
@@ -36,6 +31,7 @@ final class ListFailedTasksCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('scheduler:list:failed')
             ->setDescription(description: 'List all the failed tasks')
         ;
     }

--- a/src/Command/ListTasksCommand.php
+++ b/src/Command/ListTasksCommand.php
@@ -32,11 +32,6 @@ use const DATE_ATOM;
 final class ListTasksCommand extends Command
 {
     /**
-     * @var string|null
-     */
-    protected static $defaultName = 'scheduler:list';
-
-    /**
      * {@inheritdoc}
      */
     public function __construct(private SchedulerInterface $scheduler)
@@ -50,6 +45,7 @@ final class ListTasksCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('scheduler:list')
             ->setDescription(description: 'List the tasks')
             ->setDefinition([
                 new InputOption(name: 'expression', shortcut: null, mode: InputOption::VALUE_OPTIONAL, description: 'The expression of the tasks'),

--- a/src/Command/RebootSchedulerCommand.php
+++ b/src/Command/RebootSchedulerCommand.php
@@ -29,11 +29,6 @@ final class RebootSchedulerCommand extends Command
 {
     private LoggerInterface $logger;
 
-    /**
-     * @var string|null
-     */
-    protected static $defaultName = 'scheduler:reboot';
-
     public function __construct(
         private SchedulerInterface $scheduler,
         private WorkerInterface $worker,
@@ -51,6 +46,7 @@ final class RebootSchedulerCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('scheduler:reboot')
             ->setDefinition([
                 new InputOption(name: 'dry-run', shortcut: 'd', mode: InputOption::VALUE_NONE, description: 'Test the reboot without executing the tasks, the "ready to reboot" tasks are displayed'),
             ])

--- a/src/Command/RemoveFailedTaskCommand.php
+++ b/src/Command/RemoveFailedTaskCommand.php
@@ -25,11 +25,6 @@ use function sprintf;
  */
 final class RemoveFailedTaskCommand extends Command
 {
-    /**
-     * @var string|null
-     */
-    protected static $defaultName = 'scheduler:remove:failed';
-
     public function __construct(
         private SchedulerInterface $scheduler,
         private WorkerInterface $worker
@@ -43,6 +38,7 @@ final class RemoveFailedTaskCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('scheduler:remove:failed')
             ->setDescription(description: 'Remove given task from the scheduler')
             ->setDefinition([
                 new InputArgument(name: 'name', mode: InputArgument::REQUIRED, description: 'The name of the task to remove'),

--- a/src/Command/RetryFailedTaskCommand.php
+++ b/src/Command/RetryFailedTaskCommand.php
@@ -31,11 +31,6 @@ final class RetryFailedTaskCommand extends Command
 {
     private LoggerInterface $logger;
 
-    /**
-     * @var string|null
-     */
-    protected static $defaultName = 'scheduler:retry:failed';
-
     public function __construct(
         private WorkerInterface $worker,
         private EventDispatcherInterface $eventDispatcher,
@@ -52,6 +47,7 @@ final class RetryFailedTaskCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('scheduler:retry:failed')
             ->setDescription(description: 'Retries one or more tasks from the failed tasks')
             ->setDefinition([
                 new InputArgument(name: 'name', mode: InputArgument::REQUIRED, description: 'Specific task name(s) to retry'),

--- a/src/Command/YieldTaskCommand.php
+++ b/src/Command/YieldTaskCommand.php
@@ -22,11 +22,6 @@ use Throwable;
  */
 final class YieldTaskCommand extends Command
 {
-    /**
-     * @var string|null
-     */
-    protected static $defaultName = 'scheduler:yield';
-
     public function __construct(private SchedulerInterface $scheduler)
     {
         parent::__construct();
@@ -38,6 +33,7 @@ final class YieldTaskCommand extends Command
     protected function configure(): void
     {
         $this
+            ->setName('scheduler:yield')
             ->setDescription(description: 'Yield a task')
             ->setDefinition([
                 new InputArgument(name: 'name', mode: InputArgument::REQUIRED, description: 'The task to yield'),


### PR DESCRIPTION
Fixes "Relying on the static property "$defaultName" for setting a command name is deprecated." thrown since Symfony 6.1.