### PR TITLE
Fix Normalizers deprecations

### DIFF
--- a/phpstan.neon.8.0.dist
+++ b/phpstan.neon.8.0.dist
@@ -16,3 +16,5 @@ parameters:
         - '#Instantiated class Fiber not found#'
         - '#Call to method start\(\) on an unknown class Fiber#'
         - '#Call to static method suspend\(\) on an unknown class Fiber#'
+        # The following can be dropped once Symfony 7.0+ will be required
+        - '#Method .* has parameter \$context with no value type specified in iterable type array.#'

--- a/phpstan.neon.8.1.dist
+++ b/phpstan.neon.8.1.dist
@@ -12,3 +12,6 @@ parameters:
         - tests
     excludePaths:
         - vendor
+    ignoreErrors:
+        # The following can be dropped once Symfony 7.0+ will be required
+        - '#Method .* has parameter \$context with no value type specified in iterable type array.#'

--- a/src/Serializer/AccessLockBagNormalizer.php
+++ b/src/Serializer/AccessLockBagNormalizer.php
@@ -67,7 +67,7 @@ final class AccessLockBagNormalizer implements NormalizerInterface, Denormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null): bool
+    public function supportsNormalization($data, string $format = null, array $context = []): bool
     {
         return $data instanceof AccessLockBag;
     }
@@ -93,7 +93,7 @@ final class AccessLockBagNormalizer implements NormalizerInterface, Denormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, string $type, string $format = null): bool
+    public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
     {
         return AccessLockBag::class === $type;
     }

--- a/src/Serializer/NotificationTaskBagNormalizer.php
+++ b/src/Serializer/NotificationTaskBagNormalizer.php
@@ -59,7 +59,7 @@ final class NotificationTaskBagNormalizer implements DenormalizerInterface, Norm
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null): bool
+    public function supportsNormalization($data, string $format = null, array $context = []): bool
     {
         return $data instanceof NotificationTaskBag;
     }
@@ -86,7 +86,7 @@ final class NotificationTaskBagNormalizer implements DenormalizerInterface, Norm
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, string $type, string $format = null): bool
+    public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
     {
         return NotificationTaskBag::class === $type;
     }

--- a/src/Serializer/SchedulerConfigurationNormalizer.php
+++ b/src/Serializer/SchedulerConfigurationNormalizer.php
@@ -59,7 +59,7 @@ final class SchedulerConfigurationNormalizer implements NormalizerInterface, Den
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization($data, string $format = null, array $context = []): bool
     {
         return $data instanceof SchedulerConfiguration;
     }
@@ -87,7 +87,7 @@ final class SchedulerConfigurationNormalizer implements NormalizerInterface, Den
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, string $type, string $format = null)
+    public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
     {
         return SchedulerConfiguration::class === $type;
     }

--- a/src/Serializer/TaskNormalizer.php
+++ b/src/Serializer/TaskNormalizer.php
@@ -187,7 +187,7 @@ final class TaskNormalizer implements DenormalizerInterface, NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null): bool
+    public function supportsNormalization($data, string $format = null, array $context = []): bool
     {
         return $data instanceof TaskInterface;
     }
@@ -330,7 +330,7 @@ final class TaskNormalizer implements DenormalizerInterface, NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, string $type, string $format = null): bool
+    public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
     {
         return is_array($data) && array_key_exists(self::NORMALIZATION_DISCRIMINATOR, $data) || $type === TaskInterface::class;
     }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | N/A
| Bundle version?  | 0.9.3
| Symfony version? | 6.1.0
| New feature?     | no
| Bug fix?         | no
| Discussion?      | N/A

This PR fixes Normalizer deprecations that are triggered since Symfony 6.1 like:

> The "SchedulerBundle\Serializer\NotificationTaskBagNormalizer::supportsNormalization()" method will require a new "array $context" argument in the next major version of its interface "Symfony\Component\Serializer\Normalizer\NormalizerInterface", not defining it is deprecated.