### PR TITLE
Replace snyk with symfonycorp/security-checker-action

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -45,9 +45,10 @@ jobs:
           dependency-versions: ${{ matrix.composer-dependencies }}
           composer-options: "--prefer-stable --ignore-platform-reqs"
 
-      - name: Run Snyk to check for vulnerabilities # See https://github.com/snyk/actions/tree/master/php
-        uses: snyk/actions/php@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      - uses: actions/cache@v2
+        id: cache-db
         with:
-          command: monitor
+          path: ~/.symfony/cache
+          key: db
+
+      - uses: symfonycorp/security-checker-action@v3


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | N/A
| Bundle version?  | N/A
| Symfony version? | N/A
| New feature?     | no
| Bug fix?         | quite: fix security workflow
| Discussion?      | N/A

# Context

CI is regularly failing for PRs/pushes from people who are not the owner.

This PR is a try with symfonycorp/security-checker-action instead of snyk.

Would close #208 

# Expected behaviour

CI pass

# Stack trace

See other PRs like #266 

# Additional informations

Replaced snyk with symfonycorp/security-checker-action