### PR TITLE
Drop macOS from Rector & Static analysis workflows

### DIFF
--- a/.github/workflows/rector.yml
+++ b/.github/workflows/rector.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         php-versions: ['8.0', '8.1']
         composer-dependencies: ['highest', 'lowest']
-        os: ['ubuntu-latest', 'macOS-latest']
+        os: ['ubuntu-latest']
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         php-versions: ['8.0', '8.1']
         composer-dependencies: ['highest', 'lowest']
-        os: ['ubuntu-latest', 'macOS-latest']
+        os: ['ubuntu-latest']
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Following https://github.com/Guikingone/SchedulerBundle/issues/209#issuecomment-982376640

I'm dropping macOS-latest from Rector & Static analysis workflows as they slow down the CI, are not really useful & have to be chained (apparently only one can run at a time).

I'm leaving the Docker workflow for now, let's see what to do with it in the future :)

[Edit] macOS-latest was removed in Docker workflow by #268 