### PR TITLE
fix(bridge): exception thrown during task creation

### DIFF
--- a/src/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Bridge/Doctrine/Transport/Connection.php
@@ -139,7 +139,7 @@ final class Connection extends AbstractDoctrineConnection implements ConnectionI
         )->fetchOne();
 
         if (0 !== (int) $existingTask) {
-            return;
+            throw new TransportException(sprintf('The task "%s" has already been scheduled!', $task->getName()));
         }
 
         try {

--- a/src/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Bridge/Doctrine/Transport/Connection.php
@@ -93,7 +93,7 @@ final class Connection extends AbstractDoctrineConnection implements ConnectionI
         )->fetchOne();
 
         if (0 === (int) $statement) {
-            throw new TransportException(sprintf('The task "%s" cannot be found', $taskName));
+            throw new TransportException(message: sprintf('The task "%s" cannot be found', $taskName));
         }
 
         try {

--- a/src/Bridge/Redis/Transport/Connection.php
+++ b/src/Bridge/Redis/Transport/Connection.php
@@ -85,7 +85,7 @@ final class Connection implements ConnectionInterface
     public function create(TaskInterface $task): void
     {
         if ($this->connection->hExists($this->list, $task->getName())) {
-            throw new TransportException(sprintf('The task "%s" has already been scheduled!', $task->getName()));
+            throw new TransportException(message: sprintf('The task "%s" has already been scheduled!', $task->getName()));
         }
 
         $data = $this->serializer->serialize($task, 'json');

--- a/tests/Bridge/Doctrine/Transport/AbstractConnectionIntegrationTest.php
+++ b/tests/Bridge/Doctrine/Transport/AbstractConnectionIntegrationTest.php
@@ -179,6 +179,9 @@ abstract class AbstractConnectionIntegrationTest extends TestCase
         $this->connection->create(new NullTask('foo'));
         self::assertInstanceOf(NullTask::class, $this->connection->get('foo'));
 
+        self::expectException(TransportException::class);
+        self::expectExceptionMessage('The task "foo" has already been scheduled!');
+        self::expectExceptionCode(0);
         $this->connection->create(new ShellTask('foo', []));
         self::assertInstanceOf(NullTask::class, $this->connection->get('foo'));
     }

--- a/tests/Bridge/Doctrine/Transport/ConnectionIntegrationTest.php
+++ b/tests/Bridge/Doctrine/Transport/ConnectionIntegrationTest.php
@@ -195,6 +195,9 @@ final class ConnectionIntegrationTest extends TestCase
         $this->connection->create(new NullTask('foo'));
         self::assertInstanceOf(NullTask::class, $this->connection->get('foo'));
 
+        self::expectException(TransportException::class);
+        self::expectExceptionMessage('The task "foo" has already been scheduled!');
+        self::expectExceptionCode(0);
         $this->connection->create(new ShellTask('foo', []));
         self::assertInstanceOf(NullTask::class, $this->connection->get('foo'));
     }

--- a/tests/Bridge/Doctrine/Transport/ConnectionTest.php
+++ b/tests/Bridge/Doctrine/Transport/ConnectionTest.php
@@ -316,8 +316,7 @@ final class ConnectionTest extends TestCase
     {
         $serializer = $this->createMock(SerializerInterface::class);
 
-        $task = $this->createMock(TaskInterface::class);
-        $task->expects(self::once())->method('getName')->willReturn('foo');
+        $task = new NullTask('foo');
 
         $expressionBuilder = $this->createMock(ExpressionBuilder::class);
         $expressionBuilder->expects(self::once())->method('eq')

--- a/tests/Bridge/Doctrine/Transport/ConnectionTest.php
+++ b/tests/Bridge/Doctrine/Transport/ConnectionTest.php
@@ -7,12 +7,12 @@ namespace Tests\SchedulerBundle\Bridge\Doctrine\Transport;
 use Doctrine\DBAL\Configuration;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Result;
-use Doctrine\DBAL\Result as NextResult;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\ParameterType;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
+use Doctrine\DBAL\Result as NextResult;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Comparator;
@@ -259,7 +259,7 @@ final class ConnectionTest extends TestCase
         $serializer = $this->createMock(SerializerInterface::class);
 
         $task = $this->createMock(TaskInterface::class);
-        $task->expects(self::once())->method('getName')->willReturn('foo');
+        $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
 
         $expressionBuilder = $this->createMock(ExpressionBuilder::class);
         $expressionBuilder->expects(self::once())->method('eq')
@@ -295,7 +295,6 @@ final class ConnectionTest extends TestCase
         $driverConnection = $this->getDBALConnectionMock();
         $driverConnection->expects(self::once())->method('executeQuery')->willReturn($statement);
         $driverConnection->expects(self::once())->method('createQueryBuilder')->willReturn($queryBuilder);
-        $driverConnection->expects(self::never())->method('transactional');
 
         $connection = new DoctrineConnection(new InMemoryConfiguration([
             'auto_setup' => true,
@@ -306,6 +305,10 @@ final class ConnectionTest extends TestCase
         ]), $driverConnection, $serializer, new SchedulePolicyOrchestrator([
             new FirstInFirstOutPolicy(),
         ]));
+
+        self::expectException(TransportException::class);
+        self::expectExceptionMessage('The task "foo" has already been scheduled!');
+        self::expectExceptionCode(0);
         $connection->create($task);
     }
 

--- a/tests/Bridge/Doctrine/Transport/DoctrineTransportTest.php
+++ b/tests/Bridge/Doctrine/Transport/DoctrineTransportTest.php
@@ -23,6 +23,7 @@ use SchedulerBundle\SchedulePolicy\FirstInFirstOutPolicy;
 use SchedulerBundle\SchedulePolicy\SchedulePolicyOrchestrator;
 use SchedulerBundle\Task\LazyTask;
 use SchedulerBundle\Task\LazyTaskList;
+use SchedulerBundle\Task\NullTask;
 use SchedulerBundle\Task\TaskInterface;
 use SchedulerBundle\Task\TaskList;
 use SchedulerBundle\Transport\Configuration\InMemoryConfiguration;
@@ -368,8 +369,7 @@ final class DoctrineTransportTest extends TestCase
     {
         $serializer = $this->createMock(SerializerInterface::class);
 
-        $task = $this->createMock(TaskInterface::class);
-        $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
+        $task = new NullTask('foo');
 
         $expression = $this->createMock(ExpressionBuilder::class);
         $expression->expects(self::once())->method('eq')

--- a/tests/Bridge/Doctrine/Transport/DoctrineTransportTest.php
+++ b/tests/Bridge/Doctrine/Transport/DoctrineTransportTest.php
@@ -18,6 +18,7 @@ use JsonException;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use SchedulerBundle\Bridge\Doctrine\Transport\DoctrineTransport;
+use SchedulerBundle\Exception\TransportException;
 use SchedulerBundle\SchedulePolicy\FirstInFirstOutPolicy;
 use SchedulerBundle\SchedulePolicy\SchedulePolicyOrchestrator;
 use SchedulerBundle\Task\LazyTask;
@@ -368,7 +369,7 @@ final class DoctrineTransportTest extends TestCase
         $serializer = $this->createMock(SerializerInterface::class);
 
         $task = $this->createMock(TaskInterface::class);
-        $task->expects(self::once())->method('getName')->willReturn('foo');
+        $task->expects(self::exactly(2))->method('getName')->willReturn('foo');
 
         $expression = $this->createMock(ExpressionBuilder::class);
         $expression->expects(self::once())->method('eq')
@@ -427,6 +428,9 @@ final class DoctrineTransportTest extends TestCase
             new FirstInFirstOutPolicy(),
         ]));
 
+        self::expectException(TransportException::class);
+        self::expectExceptionMessage('The task "foo" has already been scheduled!');
+        self::expectExceptionCode(0);
         $transport->create($task);
     }
 


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | >= 8.0
| Bundle version?  | 0.9.4
| Symfony version? | >= 5.4
| New feature?     | no
| Bug fix?         | yes
| BC break?         | no

# Context

If a task already exists, on Redis we've got an [exception](https://github.com/Guikingone/SchedulerBundle/blob/main/src/Bridge/Redis/Transport/Connection.php#L88) but not with [Doctrine](https://github.com/Guikingone/SchedulerBundle/blob/main/src/Bridge/Doctrine/Transport/Connection.php#L142).

Just fix this logic

**/!\ BC break**