### PR TITLE
Pin apt versions for Dockerfile

### DIFF
--- a/.cloud/docker/Dockerfile
+++ b/.cloud/docker/Dockerfile
@@ -7,7 +7,7 @@ ENV SCHEDULER_REDIS_DSN 'redis://redis:6379/_symfony_scheduler_tasks'
 WORKDIR /srv/app
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libzip-dev zip redis git libpq-dev \
+    && apt-get install -y --no-install-recommends libzip-dev=1.7.3-1 zip=3.0-12 redis=5:6.0.16-1+deb11u2 git=1:2.30.2-1 libpq-dev=13.7-0+deb11u1 \
     && pecl install redis xdebug \
     && docker-php-ext-install pcntl zip pdo_pgsql \
     && docker-php-ext-enable pcntl xdebug redis pdo_pgsql \


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | N/A
| Bundle version?  | 0.9.4
| Symfony version? | N/A
| New feature?     | no
| Bug fix?         | yes
| Discussion?      | N/A

This PR pins back apt versions in Dockerfile, to try to make the Docker linting workflow work again.

Tested locally, let's see if it passes on CI.
