### PR TITLE
refactor(messenger): fix deprecations symfony 6.2

### DIFF
--- a/src/Messenger/TaskToExecuteMessageHandler.php
+++ b/src/Messenger/TaskToExecuteMessageHandler.php
@@ -11,7 +11,7 @@ use Exception;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use SchedulerBundle\Worker\WorkerConfiguration;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use SchedulerBundle\Worker\WorkerInterface;
 
 use function sprintf;
@@ -19,7 +19,8 @@ use function sprintf;
 /**
  * @author Guillaume Loulier <contact@guillaumeloulier.fr>
  */
-final class TaskToExecuteMessageHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class TaskToExecuteMessageHandler
 {
     private LoggerInterface $logger;
 

--- a/src/Messenger/TaskToPauseMessageHandler.php
+++ b/src/Messenger/TaskToPauseMessageHandler.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace SchedulerBundle\Messenger;
 
 use SchedulerBundle\SchedulerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * @author Guillaume Loulier <contact@guillaumeloulier.fr>
  */
-final class TaskToPauseMessageHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class TaskToPauseMessageHandler
 {
     public function __construct(private SchedulerInterface $scheduler)
     {

--- a/src/Messenger/TaskToUpdateMessageHandler.php
+++ b/src/Messenger/TaskToUpdateMessageHandler.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace SchedulerBundle\Messenger;
 
 use SchedulerBundle\Transport\TransportInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * @author Guillaume Loulier <contact@guillaumeloulier.fr>
  */
-final class TaskToUpdateMessageHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class TaskToUpdateMessageHandler
 {
     public function __construct(private TransportInterface $transport)
     {

--- a/src/Messenger/TaskToYieldMessageHandler.php
+++ b/src/Messenger/TaskToYieldMessageHandler.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace SchedulerBundle\Messenger;
 
 use SchedulerBundle\SchedulerInterface;
-use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
 /**
  * @author Guillaume Loulier <contact@guillaumeloulier.fr>
  */
-final class TaskToYieldMessageHandler implements MessageHandlerInterface
+#[AsMessageHandler]
+final class TaskToYieldMessageHandler
 {
     public function __construct(private SchedulerInterface $scheduler)
     {


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | 8.x
| Bundle version?  | 0.10.1
| Symfony version? | 6.2
| New feature?     | no
| Bug fix?         | no

# Context

Symfony 6.2 deprecates MessageHandlerInterface and recommends using the attribute.

The attribute exists since Symfony 5.4 so no fallback should be needed.
