### PR TITLE
fix(bridge): misnamed auth option in Redis transport factory

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Run PHPUnit
         run: php vendor/bin/phpunit tests -v
         env:
-          SCHEDULER_REDIS_DSN: 'redis://127.0.0.1:6379/_symfony_scheduler_tasks'
+          SCHEDULER_REDIS_DSN: 'redis://127.0.0.1:6379/_symfony_scheduler_tasks?auth=password'
           SCHEDULER_POSTGRES_DSN: 'postgres://postgres:postgres@127.0.0.1:5432/_symfony_scheduler_tasks'
 
       - name: Cache PHPUnit result

--- a/src/Bridge/Redis/Transport/RedisTransportFactory.php
+++ b/src/Bridge/Redis/Transport/RedisTransportFactory.php
@@ -51,7 +51,7 @@ final class RedisTransportFactory implements TransportFactoryInterface
             'port' => $dsn->getPort() ?? 6379,
             'scheme' => $dsn->getScheme(),
             'timeout' => $dsn->getOption('timeout', 30),
-            'auth' => $dsn->getOption('host'),
+            'auth' => $dsn->getOption('auth'),
             'dbindex' => $dsn->getOption('dbindex'),
             'transaction_mode' => $dsn->getOption('transaction_mode'),
             'execution_mode' => $dsn->getOption('execution_mode', 'first_in_first_out'),

--- a/tests/Bridge/Redis/Transport/ConnectionIntegrationTest.php
+++ b/tests/Bridge/Redis/Transport/ConnectionIntegrationTest.php
@@ -74,7 +74,7 @@ final class ConnectionIntegrationTest extends TestCase
                 'port' => $dsn->getPort(),
                 'scheme' => $dsn->getScheme(),
                 'timeout' => $dsn->getOption('timeout', 30),
-                'auth' => $dsn->getOption('host'),
+                'auth' => $dsn->getOption('auth'),
                 'list' => $dsn->getOption('list', '_symfony_scheduler_tasks'),
                 'dbindex' => $dsn->getOption('dbindex', 0),
                 'transaction_mode' => $dsn->getOption('transaction_mode'),

--- a/tests/Bridge/Redis/Transport/RedisTransportFactoryTest.php
+++ b/tests/Bridge/Redis/Transport/RedisTransportFactoryTest.php
@@ -49,6 +49,7 @@ final class RedisTransportFactoryTest extends TestCase
         self::assertSame($dsn->getPort(), $transport->getConfiguration()->get('port'));
         self::assertSame($dsn->getScheme(), $transport->getConfiguration()->get('scheme'));
         self::assertSame($dsn->getOption('timeout', 30), $transport->getConfiguration()->get('timeout'));
+        self::assertSame($dsn->getOption('auth'), $this->transport->getConfiguration()->get('auth'));
         self::assertArrayHasKey('execution_mode', $transport->getConfiguration()->toArray());
         self::assertSame('first_in_first_out', $transport->getConfiguration()->get('execution_mode'));
         self::assertArrayHasKey('list', $transport->getConfiguration()->toArray());

--- a/tests/Bridge/Redis/Transport/RedisTransportIntegrationTest.php
+++ b/tests/Bridge/Redis/Transport/RedisTransportIntegrationTest.php
@@ -77,7 +77,7 @@ final class RedisTransportIntegrationTest extends TestCase
                 'port' => $dsn->getPort(),
                 'scheme' => $dsn->getScheme(),
                 'timeout' => $dsn->getOption('timeout', 30),
-                'auth' => $dsn->getOption('host'),
+                'auth' => $dsn->getOption('auth'),
                 'list' => $dsn->getOption('list', '_symfony_scheduler_tasks'),
                 'dbindex' => $dsn->getOption('dbindex', 0),
                 'transaction_mode' => $dsn->getOption('transaction_mode'),
@@ -101,6 +101,7 @@ final class RedisTransportIntegrationTest extends TestCase
             self::assertSame($dsn->getPort(), $this->transport->getConfiguration()->get('port'));
             self::assertSame($dsn->getScheme(), $this->transport->getConfiguration()->get('scheme'));
             self::assertSame($dsn->getOption('timeout', 30), $this->transport->getConfiguration()->get('timeout'));
+            self::assertSame($dsn->getOption('auth'), $this->transport->getConfiguration()->get('auth'));
             self::assertArrayHasKey('execution_mode', $this->transport->getConfiguration()->toArray());
             self::assertSame('first_in_first_out', $this->transport->getConfiguration()->get('execution_mode'));
             self::assertArrayHasKey('list', $this->transport->getConfiguration()->toArray());


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | 8.1
| Bundle version?  | 0.10.2
| Symfony version? | 6.2.5
| New feature?     |no
| Bug fix?         | yes
| Discussion?      | # ...

# Context

<!-- Content -->

# Expected behaviour

<!-- Content -->

# Stack trace

<!-- Content -->

# Additional informations

<!-- Content -->
