### PR TITLE
Fix some PHPStan errors

### DIFF
--- a/src/Bridge/Doctrine/Transport/Configuration/Connection.php
+++ b/src/Bridge/Doctrine/Transport/Configuration/Connection.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SchedulerBundle\Bridge\Doctrine\Transport\Configuration;
 
 use Closure;
+use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection as DbalConnection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\ParameterType;
@@ -45,7 +46,7 @@ final class Connection extends AbstractDoctrineConnection implements ExternalCon
         $qb = $this->createQueryBuilder(self::TABLE_NAME, 'stc');
         $existingKeysQuery = $qb->select('stc.configuration_key_name')
             ->where($qb->expr()->in('stc.configuration_key_name', ':keys'))
-            ->setParameter('keys', array_keys($options), DbalConnection::PARAM_STR_ARRAY)
+            ->setParameter('keys', array_keys($options), ArrayParameterType::STRING)
         ;
 
         $existingConfigurationKeys = $this->executeQuery(

--- a/tests/Bridge/Redis/Transport/RedisTransportFactoryTest.php
+++ b/tests/Bridge/Redis/Transport/RedisTransportFactoryTest.php
@@ -49,7 +49,7 @@ final class RedisTransportFactoryTest extends TestCase
         self::assertSame($dsn->getPort(), $transport->getConfiguration()->get('port'));
         self::assertSame($dsn->getScheme(), $transport->getConfiguration()->get('scheme'));
         self::assertSame($dsn->getOption('timeout', 30), $transport->getConfiguration()->get('timeout'));
-        self::assertSame($dsn->getOption('auth'), $this->transport->getConfiguration()->get('auth'));
+        self::assertSame($dsn->getOption('auth'), $transport->getConfiguration()->get('auth'));
         self::assertArrayHasKey('execution_mode', $transport->getConfiguration()->toArray());
         self::assertSame('first_in_first_out', $transport->getConfiguration()->get('execution_mode'));
         self::assertArrayHasKey('list', $transport->getConfiguration()->toArray());

--- a/tests/EventListener/StopWorkerOnFailureLimitSubscriberTest.php
+++ b/tests/EventListener/StopWorkerOnFailureLimitSubscriberTest.php
@@ -26,7 +26,7 @@ final class StopWorkerOnFailureLimitSubscriberTest extends TestCase
     public function testSubscriberCannotUseNegativeLimit(): void
     {
         self::expectException(InvalidArgumentException::class);
-        self::expectErrorMessage('The failure limit must be greater than 0, given -1');
+        self::expectExceptionMessage('The failure limit must be greater than 0, given -1');
         self::expectExceptionCode(0);
         new StopWorkerOnFailureLimitSubscriber(-1);
     }
@@ -34,7 +34,7 @@ final class StopWorkerOnFailureLimitSubscriberTest extends TestCase
     public function testSubscriberCannotUseZeroLimit(): void
     {
         self::expectException(InvalidArgumentException::class);
-        self::expectErrorMessage('The failure limit must be greater than 0, given 0');
+        self::expectExceptionMessage('The failure limit must be greater than 0, given 0');
         self::expectExceptionCode(0);
         new StopWorkerOnFailureLimitSubscriber(0);
     }

--- a/tests/Middleware/TaskLockBagMiddlewareTest.php
+++ b/tests/Middleware/TaskLockBagMiddlewareTest.php
@@ -47,7 +47,7 @@ final class TaskLockBagMiddlewareTest extends TestCase
         $middleware = new TaskLockBagMiddleware($lockFactory, $logger);
 
         self::expectException(RuntimeException::class);
-        self::expectErrorMessage(sprintf('The task "foo" must be linked to an access lock bag, consider using %s::execute() or %s::schedule()', WorkerInterface::class, SchedulerInterface::class));
+        self::expectExceptionMessage(sprintf('The task "foo" must be linked to an access lock bag, consider using %s::execute() or %s::schedule()', WorkerInterface::class, SchedulerInterface::class));
         self::expectExceptionCode(0);
         $middleware->postExecute(new NullTask('foo'), $worker);
     }

--- a/tests/SchedulePolicy/DeadlinePolicyTest.php
+++ b/tests/SchedulePolicy/DeadlinePolicyTest.php
@@ -39,7 +39,7 @@ final class DeadlinePolicyTest extends TestCase
         $deadlinePolicy = new DeadlinePolicy();
 
         self::expectException(RuntimeException::class);
-        self::expectDeprecationMessage('The arrival time must be defined, consider executing the task "foo" first');
+        self::expectExceptionMessage('The arrival time must be defined, consider executing the task "foo" first');
         self::expectExceptionCode(0);
         $deadlinePolicy->sort(new TaskList([
             $secondTask,
@@ -62,7 +62,7 @@ final class DeadlinePolicyTest extends TestCase
         $deadlinePolicy = new DeadlinePolicy();
 
         self::expectException(RuntimeException::class);
-        self::expectDeprecationMessage('The execution relative deadline must be defined, consider using SchedulerBundle\Task\TaskInterface::setExecutionRelativeDeadline()');
+        self::expectExceptionMessage('The execution relative deadline must be defined, consider using SchedulerBundle\Task\TaskInterface::setExecutionRelativeDeadline()');
         self::expectExceptionCode(0);
         $deadlinePolicy->sort(new TaskList([$secondTask, $task]));
     }


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | N/A
| Bundle version?  | 0.10.2
| Symfony version? | N/A
| New feature?     | no
| Bug fix?         | kind of
| Discussion?      | N/A

Fixing some PHPStan errors.

Not sure what's the best way to fix remaining DBAL (schema-related) & PHPUnit (`withConsecutive()` call) deprecations, so leaving them for now.
