### PR TITLE
Fix code style

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -6,7 +6,8 @@ $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
 ;
 
-$config = new PhpCsFixer\Config();
+$config = (new PhpCsFixer\Config())
+    ->setParallelConfig(PhpCsFixer\Runner\Parallel\ParallelConfigFactory::detect());
 
 return $config->setRules([
     '@PSR1' => true,

--- a/composer.json
+++ b/composer.json
@@ -131,7 +131,7 @@
         "ext-redis": "*",
         "doctrine/dbal": "^3.3.6",
         "doctrine/orm": "^2.8",
-        "friendsofphp/php-cs-fixer": "^3.13",
+        "friendsofphp/php-cs-fixer": "^3.65",
         "infection/infection": "^0.26.16",
         "marcocesarato/php-conventional-changelog": "^1.14",
         "phpdocumentor/reflection-docblock": "^5.3",

--- a/composer.json
+++ b/composer.json
@@ -131,7 +131,7 @@
         "ext-redis": "*",
         "doctrine/dbal": "^3.3.6",
         "doctrine/orm": "^2.8",
-        "friendsofphp/php-cs-fixer": "^3.65",
+        "friendsofphp/php-cs-fixer": "^3.68",
         "infection/infection": "^0.26.16",
         "marcocesarato/php-conventional-changelog": "^1.14",
         "phpdocumentor/reflection-docblock": "^5.3",

--- a/src/Bridge/Doctrine/Connection/AbstractDoctrineConnection.php
+++ b/src/Bridge/Doctrine/Connection/AbstractDoctrineConnection.php
@@ -33,7 +33,7 @@ abstract class AbstractDoctrineConnection
      */
     abstract protected function executeQuery(string $sql, array $parameters = [], array $types = []);
 
-    abstract public function configureSchema(Schema $schema, DbalConnection $dbalConnection): void;
+    abstract public function configureSchema(Schema $schema, DBALConnection $dbalConnection): void;
 
     /**
      * @throws Exception

--- a/src/Bridge/Doctrine/Transport/Configuration/Connection.php
+++ b/src/Bridge/Doctrine/Transport/Configuration/Connection.php
@@ -365,7 +365,7 @@ final class Connection extends AbstractDoctrineConnection implements ExternalCon
     /**
      * {@inheritdoc}
      */
-    public function configureSchema(Schema $schema, DBALConnection $dbalConnection): void
+    public function configureSchema(Schema $schema, DbalConnection $dbalConnection): void
     {
         if ($dbalConnection !== $this->connection) {
             return;

--- a/src/Bridge/Doctrine/Transport/Connection.php
+++ b/src/Bridge/Doctrine/Transport/Connection.php
@@ -37,7 +37,7 @@ final class Connection extends AbstractDoctrineConnection implements ConnectionI
 {
     public function __construct(
         private ConfigurationInterface $configuration,
-        private DbalConnection $dbalConnection,
+        private DBALConnection $dbalConnection,
         private SerializerInterface $serializer,
         private SchedulePolicyOrchestratorInterface $schedulePolicyOrchestrator
     ) {
@@ -294,7 +294,7 @@ final class Connection extends AbstractDoctrineConnection implements ConnectionI
         $this->configuration->set(key: 'auto_setup', value: false);
     }
 
-    public function configureSchema(Schema $schema, DbalConnection $dbalConnection): void
+    public function configureSchema(Schema $schema, DBALConnection $dbalConnection): void
     {
         if ($dbalConnection !== $this->dbalConnection) {
             return;

--- a/src/Command/ExecuteTaskCommand.php
+++ b/src/Command/ExecuteTaskCommand.php
@@ -63,9 +63,9 @@ final class ExecuteTaskCommand extends Command
         $this
             ->setDefinition([
                 new InputOption('due', 'd', InputOption::VALUE_NONE, 'Define if the filters must be applied on due tasks'),
-                new InputOption('name', null, InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'The name of the task(s) to execute'),
-                new InputOption('expression', null, InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'The expression of the task(s) to execute'),
-                new InputOption('tags', 't', InputOption::VALUE_OPTIONAL|InputOption::VALUE_IS_ARRAY, 'The tags of the task(s) to execute'),
+                new InputOption('name', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The name of the task(s) to execute'),
+                new InputOption('expression', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The expression of the task(s) to execute'),
+                new InputOption('tags', 't', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The tags of the task(s) to execute'),
             ])
             ->setHelp(
                 <<<'EOF'

--- a/tests/Command/DebugProbeCommandTest.php
+++ b/tests/Command/DebugProbeCommandTest.php
@@ -84,7 +84,7 @@ final class DebugProbeCommandTest extends TestCase
     {
         $probe = $this->createMock(ProbeInterface::class);
 
-        $executionDate = new DatetimeImmutable();
+        $executionDate = new DateTimeImmutable();
         $probeTask = new ProbeTask('foo', '/_external_path');
         $probeTask->setLastExecution($executionDate);
         $probeTask->setState(TaskInterface::PAUSED);


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | latest
| Bundle version?  | 0.10.4
| Symfony version? | /
| New feature?     | no
| Bug fix?         | no
| Discussion?      | /

# Context

Currently code style check fails with last version of PHP CS Fixer.

This PR:

- sets the min PHP CS Fixer version to last minor
- fixes code style issues
- sets parallel run with auto detect