### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/Command/ConsumeTasksCommand.php
+++ b/src/Command/ConsumeTasksCommand.php
@@ -48,7 +48,7 @@ final class ConsumeTasksCommand extends Command
         private SchedulerInterface $scheduler,
         private WorkerInterface $worker,
         private EventDispatcherInterface $eventDispatcher,
-        LoggerInterface $logger = null
+        ?LoggerInterface $logger = null
     ) {
         $this->logger = $logger ?? new NullLogger();
 

--- a/src/Command/RetryFailedTaskCommand.php
+++ b/src/Command/RetryFailedTaskCommand.php
@@ -40,7 +40,7 @@ final class RetryFailedTaskCommand extends Command
     public function __construct(
         private WorkerInterface $worker,
         private EventDispatcherInterface $eventDispatcher,
-        LoggerInterface $logger = null
+        ?LoggerInterface $logger = null
     ) {
         $this->logger = $logger ?? new NullLogger();
 

--- a/src/DataCollector/SchedulerDataCollector.php
+++ b/src/DataCollector/SchedulerDataCollector.php
@@ -38,7 +38,7 @@ final class SchedulerDataCollector extends DataCollector implements LateDataColl
     /**
      * {@inheritdoc}
      */
-    public function collect(Request $request, Response $response, Throwable $exception = null): void
+    public function collect(Request $request, Response $response, ?Throwable $exception = null): void
     {
         // As data can comes from Messenger, local or remote schedulers|workers, we should collect it as late as possible.
     }

--- a/src/EventListener/StopWorkerOnNextTaskSubscriber.php
+++ b/src/EventListener/StopWorkerOnNextTaskSubscriber.php
@@ -25,7 +25,7 @@ final class StopWorkerOnNextTaskSubscriber implements EventSubscriberInterface
 
     public function __construct(
         private CacheItemPoolInterface $stopWorkerCacheItemPool,
-        LoggerInterface $logger = null
+        ?LoggerInterface $logger = null
     ) {
         $this->logger = $logger ?? new NullLogger();
     }

--- a/src/EventListener/TaskLifecycleSubscriber.php
+++ b/src/EventListener/TaskLifecycleSubscriber.php
@@ -19,7 +19,7 @@ final class TaskLifecycleSubscriber implements EventSubscriberInterface
 {
     private LoggerInterface $logger;
 
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger ?? new NullLogger();
     }

--- a/src/EventListener/TaskSubscriber.php
+++ b/src/EventListener/TaskSubscriber.php
@@ -39,7 +39,7 @@ final class TaskSubscriber implements EventSubscriberInterface
         private WorkerInterface $worker,
         private EventDispatcherInterface $eventDispatcher,
         private SerializerInterface $serializer,
-        LoggerInterface $logger = null,
+        ?LoggerInterface $logger = null,
         private string $tasksPath = '/_tasks'
     ) {
         $this->logger = $logger ?? new NullLogger();

--- a/src/EventListener/WorkerLifecycleSubscriber.php
+++ b/src/EventListener/WorkerLifecycleSubscriber.php
@@ -22,7 +22,7 @@ final class WorkerLifecycleSubscriber implements EventSubscriberInterface
 {
     private LoggerInterface $logger;
 
-    public function __construct(LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null)
     {
         $this->logger = $logger ?? new NullLogger();
     }

--- a/src/Runner/HttpTaskRunner.php
+++ b/src/Runner/HttpTaskRunner.php
@@ -19,7 +19,7 @@ final class HttpTaskRunner implements RunnerInterface
 {
     private HttpClientInterface $httpClient;
 
-    public function __construct(HttpClientInterface $httpClient = null)
+    public function __construct(?HttpClientInterface $httpClient = null)
     {
         $this->httpClient = $httpClient ?? HttpClient::create();
     }

--- a/src/Serializer/AccessLockBagNormalizer.php
+++ b/src/Serializer/AccessLockBagNormalizer.php
@@ -37,7 +37,7 @@ final class AccessLockBagNormalizer implements NormalizerInterface, Denormalizer
      *
      * @return array<string, mixed>
      */
-    public function normalize($object, string $format = null, array $context = []): array
+    public function normalize($object, ?string $format = null, array $context = []): array
     {
         if (!$this->objectNormalizer instanceof NormalizerInterface) {
             throw new BadMethodCallException(sprintf('The "%s()" method cannot be called as injected normalizer does not implements "%s".', __METHOD__, NormalizerInterface::class));
@@ -48,7 +48,7 @@ final class AccessLockBagNormalizer implements NormalizerInterface, Denormalizer
                 'bag' => AccessLockBag::class,
                 'body' => $this->objectNormalizer->normalize(object: $object, format: $format, context: [
                     AbstractNormalizer::CALLBACKS => [
-                        'key' => static fn (Key $innerObject, AccessLockBag $outerObject, string $attributeName, string $format = null, array $context = []): string => serialize(value: $innerObject),
+                        'key' => static fn (Key $innerObject, AccessLockBag $outerObject, string $attributeName, ?string $format = null, array $context = []): string => serialize(value: $innerObject),
                     ],
                 ]),
             ];
@@ -69,7 +69,7 @@ final class AccessLockBagNormalizer implements NormalizerInterface, Denormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null, array $context = []): bool
+    public function supportsNormalization($data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof AccessLockBag;
     }
@@ -77,7 +77,7 @@ final class AccessLockBagNormalizer implements NormalizerInterface, Denormalizer
     /**
      * {@inheritdoc}
      */
-    public function denormalize($data, string $type, string $format = null, array $context = []): AccessLockBag
+    public function denormalize($data, string $type, ?string $format = null, array $context = []): AccessLockBag
     {
         if (!$this->objectNormalizer instanceof DenormalizerInterface) {
             throw new BadMethodCallException(sprintf('The "%s()" method cannot be called as injected denormalizer does not implements "%s".', __METHOD__, DenormalizerInterface::class));
@@ -99,7 +99,7 @@ final class AccessLockBagNormalizer implements NormalizerInterface, Denormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization($data, string $type, ?string $format = null, array $context = []): bool
     {
         return AccessLockBag::class === $type;
     }

--- a/src/Serializer/NotificationTaskBagNormalizer.php
+++ b/src/Serializer/NotificationTaskBagNormalizer.php
@@ -31,7 +31,7 @@ final class NotificationTaskBagNormalizer implements DenormalizerInterface, Norm
      *
      * @return array<string, mixed>
      */
-    public function normalize($object, string $format = null, array $context = []): array
+    public function normalize($object, ?string $format = null, array $context = []): array
     {
         if (!$this->objectNormalizer instanceof NormalizerInterface) {
             throw new BadMethodCallException(sprintf('The "%s()" method cannot be called as injected normalizer does not implements "%s".', __METHOD__, DenormalizerInterface::class));
@@ -41,11 +41,11 @@ final class NotificationTaskBagNormalizer implements DenormalizerInterface, Norm
             'bag' => NotificationTaskBag::class,
             'body' => $this->objectNormalizer->normalize(object: $object, format: $format, context: [
                 AbstractNormalizer::CALLBACKS => [
-                    'recipients' => static fn (array $innerObject, NotificationTaskBag $outerObject, string $attributeName, string $format = null, array $context = []): array => array_map(callback: static fn (Recipient $recipient): array => [
+                    'recipients' => static fn (array $innerObject, NotificationTaskBag $outerObject, string $attributeName, ?string $format = null, array $context = []): array => array_map(callback: static fn (Recipient $recipient): array => [
                         'email' => $recipient->getEmail(),
                         'phone' => $recipient->getPhone(),
                     ], array: $innerObject),
-                    'notification' => static fn (Notification $innerObject, NotificationTaskBag $outerObject, string $attributeName, string $format = null, array $context = []): array => [
+                    'notification' => static fn (Notification $innerObject, NotificationTaskBag $outerObject, string $attributeName, ?string $format = null, array $context = []): array => [
                         'subject' => $innerObject->getSubject(),
                         'content' => $innerObject->getContent(),
                         'emoji' => $innerObject->getEmoji(),
@@ -60,7 +60,7 @@ final class NotificationTaskBagNormalizer implements DenormalizerInterface, Norm
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null, array $context = []): bool
+    public function supportsNormalization($data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof NotificationTaskBag;
     }
@@ -68,7 +68,7 @@ final class NotificationTaskBagNormalizer implements DenormalizerInterface, Norm
     /**
      * {@inheritdoc}
      */
-    public function denormalize($data, string $type, string $format = null, array $context = []): NotificationTaskBag
+    public function denormalize($data, string $type, ?string $format = null, array $context = []): NotificationTaskBag
     {
         if (!$this->objectNormalizer instanceof DenormalizerInterface) {
             throw new BadMethodCallException(sprintf('The "%s()" method cannot be called as injected denormalizer does not implements "%s".', __METHOD__, DenormalizerInterface::class));
@@ -87,7 +87,7 @@ final class NotificationTaskBagNormalizer implements DenormalizerInterface, Norm
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization($data, string $type, ?string $format = null, array $context = []): bool
     {
         return NotificationTaskBag::class === $type;
     }

--- a/src/Serializer/SchedulerConfigurationNormalizer.php
+++ b/src/Serializer/SchedulerConfigurationNormalizer.php
@@ -36,7 +36,7 @@ final class SchedulerConfigurationNormalizer implements NormalizerInterface, Den
      *
      * @return array<string, mixed>
      */
-    public function normalize($object, string $format = null, array $context = []): array
+    public function normalize($object, ?string $format = null, array $context = []): array
     {
         if (!$this->taskNormalizer instanceof NormalizerInterface || !$this->dateTimeZoneNormalizer instanceof NormalizerInterface || !$this->dateTimeNormalizer instanceof NormalizerInterface) {
             throw new BadMethodCallException(sprintf('The "%s()" method cannot be called as injected normalizer does not implements "%s".', __METHOD__, DenormalizerInterface::class));
@@ -60,7 +60,7 @@ final class SchedulerConfigurationNormalizer implements NormalizerInterface, Den
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null, array $context = []): bool
+    public function supportsNormalization($data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof SchedulerConfiguration;
     }
@@ -68,7 +68,7 @@ final class SchedulerConfigurationNormalizer implements NormalizerInterface, Den
     /**
      * {@inheritdoc}
      */
-    public function denormalize($data, string $type, string $format = null, array $context = []): SchedulerConfiguration
+    public function denormalize($data, string $type, ?string $format = null, array $context = []): SchedulerConfiguration
     {
         if (!$this->objectNormalizer instanceof DenormalizerInterface || !$this->taskNormalizer instanceof DenormalizerInterface || !$this->dateTimeZoneNormalizer instanceof DenormalizerInterface || !$this->dateTimeNormalizer instanceof DenormalizerInterface) {
             throw new BadMethodCallException(sprintf('The "%s()" method cannot be called as injected denormalizer does not implements "%s".', __METHOD__, DenormalizerInterface::class));
@@ -88,7 +88,7 @@ final class SchedulerConfigurationNormalizer implements NormalizerInterface, Den
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization($data, string $type, ?string $format = null, array $context = []): bool
     {
         return SchedulerConfiguration::class === $type;
     }

--- a/src/Serializer/TaskNormalizer.php
+++ b/src/Serializer/TaskNormalizer.php
@@ -69,7 +69,7 @@ final class TaskNormalizer implements DenormalizerInterface, NormalizerInterface
      *
      * @return array<string, mixed>
      */
-    public function normalize($object, string $format = null, array $context = []): array
+    public function normalize($object, ?string $format = null, array $context = []): array
     {
         if (!$this->dateTimeZoneNormalizer instanceof NormalizerInterface && !$this->dateTimeNormalizer instanceof NormalizerInterface && !$this->dateIntervalNormalizer instanceof NormalizerInterface && !$this->objectNormalizer instanceof NormalizerInterface && !$this->notificationTaskBagNormalizer instanceof NormalizerInterface && !$this->accessLockBagNormalizer instanceof NormalizerInterface) {
             throw new BadMethodCallException(sprintf('The "%s()" method cannot be called as injected normalizer does not implements "%s".', __METHOD__, DenormalizerInterface::class));
@@ -79,7 +79,7 @@ final class TaskNormalizer implements DenormalizerInterface, NormalizerInterface
             throw new InvalidArgumentException(sprintf('CallbackTask with closure cannot be sent to external transport, consider executing it thanks to "%s::execute()"', Worker::class));
         }
 
-        $dateAttributesCallback = function (?DateTimeImmutable $innerObject, TaskInterface $outerObject, string $attributeName, string $format = null): ?string {
+        $dateAttributesCallback = function (?DateTimeImmutable $innerObject, TaskInterface $outerObject, string $attributeName, ?string $format = null): ?string {
             if (!$this->dateTimeNormalizer instanceof NormalizerInterface) {
                 throw new RuntimeException(sprintf('The datetime normalizer is not an instance of %s.', NormalizerInterface::class));
             }
@@ -95,7 +95,7 @@ final class TaskNormalizer implements DenormalizerInterface, NormalizerInterface
             return $result;
         };
 
-        $dateIntervalAttributesCallback = function (?DateInterval $innerObject, TaskInterface $outerObject, string $attributeName, string $format = null, array $context = []): ?string {
+        $dateIntervalAttributesCallback = function (?DateInterval $innerObject, TaskInterface $outerObject, string $attributeName, ?string $format = null, array $context = []): ?string {
             if (!$this->dateIntervalNormalizer instanceof NormalizerInterface) {
                 throw new RuntimeException(sprintf('The date interval normalizer is not an instance of %s.', NormalizerInterface::class));
             }
@@ -109,7 +109,7 @@ final class TaskNormalizer implements DenormalizerInterface, NormalizerInterface
             return $result;
         };
 
-        $notificationTaskBagCallback = function (?NotificationTaskBag $innerObject, TaskInterface $outerObject, string $attributeName, string $format = null, array $context = []): ?array {
+        $notificationTaskBagCallback = function (?NotificationTaskBag $innerObject, TaskInterface $outerObject, string $attributeName, ?string $format = null, array $context = []): ?array {
             if (!$this->notificationTaskBagNormalizer instanceof NormalizerInterface) {
                 throw new RuntimeException(sprintf('The notification task bag normalizer is not an instance of %s.', NormalizerInterface::class));
             }
@@ -123,7 +123,7 @@ final class TaskNormalizer implements DenormalizerInterface, NormalizerInterface
             return $result;
         };
 
-        $taskCallbacksAttributesCallback = function ($innerObject, TaskInterface $outerObject, string $attributeName, string $format = null, array $context = []): ?array {
+        $taskCallbacksAttributesCallback = function ($innerObject, TaskInterface $outerObject, string $attributeName, ?string $format = null, array $context = []): ?array {
             if (!$this->objectNormalizer instanceof NormalizerInterface) {
                 throw new BadMethodCallException(sprintf('The "%s()" method cannot be called as injected normalizer does not implements "%s".', __METHOD__, NormalizerInterface::class));
             }
@@ -150,7 +150,7 @@ final class TaskNormalizer implements DenormalizerInterface, NormalizerInterface
                 'executionEndTime' => $dateAttributesCallback,
                 'lastExecution' => $dateAttributesCallback,
                 'scheduledAt' => $dateAttributesCallback,
-                'timezone' => function (?DateTimeZone $innerObject, TaskInterface $outerObject, string $attributeName, string $format = null, array $context = []): ?string {
+                'timezone' => function (?DateTimeZone $innerObject, TaskInterface $outerObject, string $attributeName, ?string $format = null, array $context = []): ?string {
                     if (!$this->dateTimeZoneNormalizer instanceof NormalizerInterface) {
                         throw new RuntimeException(sprintf('The %s is not an instance of %s.', DateTimeZoneNormalizer::class, NormalizerInterface::class));
                     }
@@ -171,15 +171,15 @@ final class TaskNormalizer implements DenormalizerInterface, NormalizerInterface
                 'afterSchedulingNotificationBag' => $notificationTaskBagCallback,
                 'beforeExecutingNotificationBag' => $notificationTaskBagCallback,
                 'afterExecutingNotificationBag' => $notificationTaskBagCallback,
-                'recipients' => static fn (array $innerObject, NotificationTask $outerObject, string $attributeName, string $format = null, array $context = []): array => array_map(static fn (Recipient $recipient): array => ['email' => $recipient->getEmail(), 'phone' => $recipient->getPhone()], $innerObject),
-                'notification' => static fn (Notification $innerObject, NotificationTask $outerObject, string $attributeName, string $format = null, array $context = []): array => [
+                'recipients' => static fn (array $innerObject, NotificationTask $outerObject, string $attributeName, ?string $format = null, array $context = []): array => array_map(static fn (Recipient $recipient): array => ['email' => $recipient->getEmail(), 'phone' => $recipient->getPhone()], $innerObject),
+                'notification' => static fn (Notification $innerObject, NotificationTask $outerObject, string $attributeName, ?string $format = null, array $context = []): array => [
                     'subject' => $innerObject->getSubject(),
                     'content' => $innerObject->getContent(),
                     'emoji' => $innerObject->getEmoji(),
                     'channels' => array_merge(...array_map(static fn (Recipient $recipient): array => $innerObject->getChannels($recipient), $outerObject->getRecipients())),
                     'importance' => $innerObject->getImportance(),
                 ],
-                'message' => function ($innerObject, MessengerTask $outerObject, string $attributeName, string $format = null, array $context = []): array {
+                'message' => function ($innerObject, MessengerTask $outerObject, string $attributeName, ?string $format = null, array $context = []): array {
                     if (!$this->objectNormalizer instanceof NormalizerInterface) {
                         throw new RuntimeException(sprintf('The %s is not an instance of %s.', ObjectNormalizer::class, NormalizerInterface::class));
                     }
@@ -189,7 +189,7 @@ final class TaskNormalizer implements DenormalizerInterface, NormalizerInterface
                         'payload' => $this->objectNormalizer->normalize($innerObject, $format, $context),
                     ];
                 },
-                'callback' => function ($innerObject, TaskInterface $outerObject, string $attributeName, string $format = null, array $context = []): array {
+                'callback' => function ($innerObject, TaskInterface $outerObject, string $attributeName, ?string $format = null, array $context = []): array {
                     if (!$this->objectNormalizer instanceof NormalizerInterface) {
                         throw new RuntimeException(sprintf('The %s is not an instance of %s.', ObjectNormalizer::class, NormalizerInterface::class));
                     }
@@ -206,12 +206,12 @@ final class TaskNormalizer implements DenormalizerInterface, NormalizerInterface
                         'type' => $innerObject[0]::class,
                     ];
                 },
-                'tasks' => fn (TaskListInterface $innerObject, ChainedTask $outerObject, string $attributeName, string $format = null, array $context = []): array => array_map(fn (TaskInterface $task): array => $this->normalize($task, $format, [
+                'tasks' => fn (TaskListInterface $innerObject, ChainedTask $outerObject, string $attributeName, ?string $format = null, array $context = []): array => array_map(fn (TaskInterface $task): array => $this->normalize($task, $format, [
                     AbstractNormalizer::IGNORED_ATTRIBUTES => $task instanceof CommandTask ? [] : [
                         'options' => [],
                     ],
                 ]), $innerObject->toArray(keepKeys: false)),
-                'accessLockBag' => function (?AccessLockBag $innerObject, TaskInterface $outerObject, string $attributeName, string $format = null, array $context = []): ?array {
+                'accessLockBag' => function (?AccessLockBag $innerObject, TaskInterface $outerObject, string $attributeName, ?string $format = null, array $context = []): ?array {
                     if (!$this->accessLockBagNormalizer instanceof NormalizerInterface) {
                         throw new RuntimeException(sprintf('The %s is not an instance of %s.', AccessLockBagNormalizer::class, NormalizerInterface::class));
                     }
@@ -244,7 +244,7 @@ final class TaskNormalizer implements DenormalizerInterface, NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null, array $context = []): bool
+    public function supportsNormalization($data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof TaskInterface;
     }
@@ -252,7 +252,7 @@ final class TaskNormalizer implements DenormalizerInterface, NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function denormalize($data, string $type, string $format = null, array $context = []): TaskInterface
+    public function denormalize($data, string $type, ?string $format = null, array $context = []): TaskInterface
     {
         if (!$this->objectNormalizer instanceof DenormalizerInterface) {
             throw new BadMethodCallException(sprintf('The "%s()" method cannot be called as injected denormalizer does not implements "%s".', __METHOD__, DenormalizerInterface::class));
@@ -391,7 +391,7 @@ final class TaskNormalizer implements DenormalizerInterface, NormalizerInterface
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization($data, string $type, ?string $format = null, array $context = []): bool
     {
         return is_array(value: $data) && array_key_exists(key: self::NORMALIZATION_DISCRIMINATOR, array: $data) || $type === TaskInterface::class;
     }

--- a/src/Task/AbstractTask.php
+++ b/src/Task/AbstractTask.php
@@ -138,12 +138,12 @@ abstract class AbstractTask implements TaskInterface
         $optionsResolver->setAllowedTypes(option: 'timezone', allowedTypes: [DateTimeZone::class, 'null']);
 
         $optionsResolver->setAllowedValues(option: 'expression', allowedValues: fn (string $expression): bool => $this->validateExpression(expression: $expression));
-        $optionsResolver->setAllowedValues(option: 'execution_start_date', allowedValues: fn (string $executionStartDate = null): bool => $this->validateStartDate(date: $executionStartDate));
-        $optionsResolver->setAllowedValues(option: 'execution_end_date', allowedValues: fn (string $executionEndDate = null): bool => $this->validateEndDate(date: $executionEndDate));
-        $optionsResolver->setAllowedValues(option: 'nice', allowedValues: fn (int $nice = null): bool => $this->validateNice(nice: $nice));
+        $optionsResolver->setAllowedValues(option: 'execution_start_date', allowedValues: fn (?string $executionStartDate = null): bool => $this->validateStartDate(date: $executionStartDate));
+        $optionsResolver->setAllowedValues(option: 'execution_end_date', allowedValues: fn (?string $executionEndDate = null): bool => $this->validateEndDate(date: $executionEndDate));
+        $optionsResolver->setAllowedValues(option: 'nice', allowedValues: fn (?int $nice = null): bool => $this->validateNice(nice: $nice));
         $optionsResolver->setAllowedValues(option: 'priority', allowedValues: fn (int $priority): bool => $this->validatePriority(priority: $priority));
         $optionsResolver->setAllowedValues(option: 'state', allowedValues: fn (string $state): bool => $this->validateState(state: $state));
-        $optionsResolver->setAllowedValues(option: 'execution_state', allowedValues: fn (string $executionState = null): bool => $this->validateExecutionState(executionState: $executionState));
+        $optionsResolver->setAllowedValues(option: 'execution_state', allowedValues: fn (?string $executionState = null): bool => $this->validateExecutionState(executionState: $executionState));
 
         $optionsResolver->setNormalizer(option: 'expression', normalizer: static fn (Options $options, string $value): string => Expression::createFromString(expression: $value)->getExpression());
         $optionsResolver->setNormalizer(option: 'execution_end_date', normalizer: fn (Options $options, ?string $value): ?DateTimeImmutable => null !== $value ? new DateTimeImmutable(datetime: $value, timezone: $options['timezone'] ?? $this->getTimezone() ?? new DateTimeZone(timezone: 'UTC')) : null);
@@ -212,7 +212,7 @@ abstract class AbstractTask implements TaskInterface
     /**
      * {@inheritdoc}
      */
-    public function setArrivalTime(DateTimeImmutable $dateTimeImmutable = null): TaskInterface
+    public function setArrivalTime(?DateTimeImmutable $dateTimeImmutable = null): TaskInterface
     {
         $this->options['arrival_time'] = $dateTimeImmutable;
 
@@ -267,7 +267,7 @@ abstract class AbstractTask implements TaskInterface
         return $this->options['before_scheduling'];
     }
 
-    public function beforeSchedulingNotificationBag(NotificationTaskBag $notificationTaskBag = null): TaskInterface
+    public function beforeSchedulingNotificationBag(?NotificationTaskBag $notificationTaskBag = null): TaskInterface
     {
         $this->options['before_scheduling_notification'] = $notificationTaskBag;
 
@@ -279,7 +279,7 @@ abstract class AbstractTask implements TaskInterface
         return $this->options['before_scheduling_notification'] ?? null;
     }
 
-    public function afterSchedulingNotificationBag(NotificationTaskBag $notificationTaskBag = null): TaskInterface
+    public function afterSchedulingNotificationBag(?NotificationTaskBag $notificationTaskBag = null): TaskInterface
     {
         $this->options['after_scheduling_notification'] = $notificationTaskBag;
 
@@ -291,7 +291,7 @@ abstract class AbstractTask implements TaskInterface
         return $this->options['after_scheduling_notification'] ?? null;
     }
 
-    public function beforeExecutingNotificationBag(NotificationTaskBag $notificationTaskBag = null): TaskInterface
+    public function beforeExecutingNotificationBag(?NotificationTaskBag $notificationTaskBag = null): TaskInterface
     {
         $this->options['before_executing_notification'] = $notificationTaskBag;
 
@@ -303,7 +303,7 @@ abstract class AbstractTask implements TaskInterface
         return $this->options['before_executing_notification'] ?? null;
     }
 
-    public function afterExecutingNotificationBag(NotificationTaskBag $notificationTaskBag = null): TaskInterface
+    public function afterExecutingNotificationBag(?NotificationTaskBag $notificationTaskBag = null): TaskInterface
     {
         $this->options['after_executing_notification'] = $notificationTaskBag;
 
@@ -369,7 +369,7 @@ abstract class AbstractTask implements TaskInterface
         return $this->options['after_executing'];
     }
 
-    public function setDescription(string $description = null): TaskInterface
+    public function setDescription(?string $description = null): TaskInterface
     {
         $this->options['description'] = $description;
 
@@ -397,7 +397,7 @@ abstract class AbstractTask implements TaskInterface
         return $this->options['expression'] ?? '* * * * *';
     }
 
-    public function setExecutionAbsoluteDeadline(DateInterval $dateInterval = null): TaskInterface
+    public function setExecutionAbsoluteDeadline(?DateInterval $dateInterval = null): TaskInterface
     {
         $this->options['execution_absolute_deadline'] = $dateInterval;
 
@@ -417,7 +417,7 @@ abstract class AbstractTask implements TaskInterface
     /**
      * {@internal Used by the TaskExecutionTracker and the ExecutionModeOrchestrator to evaluate the time spent by the worker to execute this task and sort it if required}.
      */
-    public function setExecutionComputationTime(float $executionComputationTime = null): TaskInterface
+    public function setExecutionComputationTime(?float $executionComputationTime = null): TaskInterface
     {
         $this->options['execution_computation_time'] = $executionComputationTime;
 
@@ -429,7 +429,7 @@ abstract class AbstractTask implements TaskInterface
         return $this->options['execution_delay'] ?? null;
     }
 
-    public function setExecutionDelay(int $executionDelay = null): TaskInterface
+    public function setExecutionDelay(?int $executionDelay = null): TaskInterface
     {
         $this->options['execution_delay'] = $executionDelay;
 
@@ -457,7 +457,7 @@ abstract class AbstractTask implements TaskInterface
         return $this->options['execution_period'] ?? null;
     }
 
-    public function setExecutionPeriod(float $executionPeriod = null): TaskInterface
+    public function setExecutionPeriod(?float $executionPeriod = null): TaskInterface
     {
         $this->options['execution_period'] = $executionPeriod;
 
@@ -469,7 +469,7 @@ abstract class AbstractTask implements TaskInterface
         return $this->options['execution_relative_deadline'] ?? null;
     }
 
-    public function setExecutionRelativeDeadline(DateInterval $dateInterval = null): TaskInterface
+    public function setExecutionRelativeDeadline(?DateInterval $dateInterval = null): TaskInterface
     {
         $this->options['execution_relative_deadline'] = $dateInterval;
 
@@ -479,7 +479,7 @@ abstract class AbstractTask implements TaskInterface
     /**
      * @throws Exception
      */
-    public function setExecutionStartDate(string $executionStartDate = null): TaskInterface
+    public function setExecutionStartDate(?string $executionStartDate = null): TaskInterface
     {
         if (!$this->validateStartDate(date: $executionStartDate)) {
             throw new InvalidArgumentException(message: 'The date could not be created');
@@ -501,7 +501,7 @@ abstract class AbstractTask implements TaskInterface
     /**
      * @throws Exception
      */
-    public function setExecutionEndDate(string $executionEndDate = null): TaskInterface
+    public function setExecutionEndDate(?string $executionEndDate = null): TaskInterface
     {
         if (!$this->validateEndDate(date: $executionEndDate)) {
             throw new InvalidArgumentException(message: 'The date could not be created');
@@ -520,7 +520,7 @@ abstract class AbstractTask implements TaskInterface
         return $this->options['execution_end_date'];
     }
 
-    public function setExecutionStartTime(DateTimeImmutable $dateTimeImmutable = null): TaskInterface
+    public function setExecutionStartTime(?DateTimeImmutable $dateTimeImmutable = null): TaskInterface
     {
         $this->options['execution_start_time'] = $dateTimeImmutable;
 
@@ -535,7 +535,7 @@ abstract class AbstractTask implements TaskInterface
         return $this->options['execution_start_time'] instanceof DateTimeImmutable ? $this->options['execution_start_time'] : null;
     }
 
-    public function setExecutionEndTime(DateTimeImmutable $dateTimeImmutable = null): TaskInterface
+    public function setExecutionEndTime(?DateTimeImmutable $dateTimeImmutable = null): TaskInterface
     {
         $this->options['execution_end_time'] = $dateTimeImmutable;
 
@@ -566,7 +566,7 @@ abstract class AbstractTask implements TaskInterface
         $this->options['access_lock_bag'] = $bag;
     }
 
-    public function setLastExecution(DateTimeImmutable $dateTimeImmutable = null): TaskInterface
+    public function setLastExecution(?DateTimeImmutable $dateTimeImmutable = null): TaskInterface
     {
         $this->options['last_execution'] = $dateTimeImmutable;
 
@@ -578,7 +578,7 @@ abstract class AbstractTask implements TaskInterface
         return $this->options['last_execution'] instanceof DateTimeImmutable ? $this->options['last_execution'] : null;
     }
 
-    public function setMaxDuration(float $maxDuration = null): TaskInterface
+    public function setMaxDuration(?float $maxDuration = null): TaskInterface
     {
         $this->options['max_duration'] = $maxDuration;
 
@@ -590,7 +590,7 @@ abstract class AbstractTask implements TaskInterface
         return is_float(value: $this->options['max_duration']) ? $this->options['max_duration'] : null;
     }
 
-    public function setMaxExecutions(int $maxExecutions = null): TaskInterface
+    public function setMaxExecutions(?int $maxExecutions = null): TaskInterface
     {
         $this->options['max_executions'] = $maxExecutions;
 
@@ -602,7 +602,7 @@ abstract class AbstractTask implements TaskInterface
         return is_int(value: $this->options['max_executions']) ? $this->options['max_executions'] : null;
     }
 
-    public function setMaxRetries(int $maxRetries = null): TaskInterface
+    public function setMaxRetries(?int $maxRetries = null): TaskInterface
     {
         $this->options['max_retries'] = $maxRetries;
 
@@ -619,7 +619,7 @@ abstract class AbstractTask implements TaskInterface
         return is_int(value: $this->options['nice']) ? $this->options['nice'] : null;
     }
 
-    public function setNice(int $nice = null): TaskInterface
+    public function setNice(?int $nice = null): TaskInterface
     {
         if (!$this->validateNice(nice: $nice)) {
             throw new InvalidArgumentException(message: 'The nice value is not valid');
@@ -666,7 +666,7 @@ abstract class AbstractTask implements TaskInterface
     /**
      * {@inheritdoc}
      */
-    public function setExecutionState(string $executionState = null): TaskInterface
+    public function setExecutionState(?string $executionState = null): TaskInterface
     {
         if (!$this->validateExecutionState(executionState: $executionState)) {
             throw new InvalidArgumentException(message: 'This execution state is not allowed');
@@ -727,7 +727,7 @@ abstract class AbstractTask implements TaskInterface
         return $this;
     }
 
-    public function setScheduledAt(DateTimeImmutable $scheduledAt = null): TaskInterface
+    public function setScheduledAt(?DateTimeImmutable $scheduledAt = null): TaskInterface
     {
         $this->options['scheduled_at'] = $scheduledAt;
 
@@ -797,7 +797,7 @@ abstract class AbstractTask implements TaskInterface
         return (array_key_exists(key: 'timezone', array: $this->options) && $this->options['timezone'] instanceof DateTimeZone) ? $this->options['timezone'] : null;
     }
 
-    public function setTimezone(DateTimeZone $dateTimeZone = null): TaskInterface
+    public function setTimezone(?DateTimeZone $dateTimeZone = null): TaskInterface
     {
         $this->options['timezone'] = $dateTimeZone;
 
@@ -825,7 +825,7 @@ abstract class AbstractTask implements TaskInterface
         return in_array(needle: $expression, haystack: Expression::ALLOWED_MACROS, strict: true);
     }
 
-    private function validateNice(int $nice = null): bool
+    private function validateNice(?int $nice = null): bool
     {
         if (null === $nice) {
             return true;
@@ -848,7 +848,7 @@ abstract class AbstractTask implements TaskInterface
         return in_array(needle: $state, haystack: TaskInterface::ALLOWED_STATES, strict: true);
     }
 
-    private function validateExecutionState(string $executionState = null): bool
+    private function validateExecutionState(?string $executionState = null): bool
     {
         return null === $executionState || in_array(needle: $executionState, haystack: TaskInterface::EXECUTION_STATES, strict: true);
     }

--- a/src/Task/ShellTask.php
+++ b/src/Task/ShellTask.php
@@ -22,7 +22,7 @@ final class ShellTask extends AbstractTask
     public function __construct(
         string $name,
         array $command,
-        string $cwd = null,
+        ?string $cwd = null,
         array $environmentVariables = [],
         float $timeout = 60.0,
         array $options = []

--- a/src/Task/TaskInterface.php
+++ b/src/Task/TaskInterface.php
@@ -114,7 +114,7 @@ interface TaskInterface
     /**
      * Set the date from which the task has been retrieved by the worker and started its execution.
      */
-    public function setArrivalTime(DateTimeImmutable $dateTimeImmutable = null): self;
+    public function setArrivalTime(?DateTimeImmutable $dateTimeImmutable = null): self;
 
     /**
      * Return the date from which the task has been retrieved by the worker and started its execution.
@@ -141,19 +141,19 @@ interface TaskInterface
      */
     public function getBeforeScheduling(): callable|array|null;
 
-    public function beforeSchedulingNotificationBag(NotificationTaskBag $notificationTaskBag = null): TaskInterface;
+    public function beforeSchedulingNotificationBag(?NotificationTaskBag $notificationTaskBag = null): TaskInterface;
 
     public function getBeforeSchedulingNotificationBag(): ?NotificationTaskBag;
 
-    public function afterSchedulingNotificationBag(NotificationTaskBag $notificationTaskBag = null): TaskInterface;
+    public function afterSchedulingNotificationBag(?NotificationTaskBag $notificationTaskBag = null): TaskInterface;
 
     public function getAfterSchedulingNotificationBag(): ?NotificationTaskBag;
 
-    public function beforeExecutingNotificationBag(NotificationTaskBag $notificationTaskBag = null): TaskInterface;
+    public function beforeExecutingNotificationBag(?NotificationTaskBag $notificationTaskBag = null): TaskInterface;
 
     public function getBeforeExecutingNotificationBag(): ?NotificationTaskBag;
 
-    public function afterExecutingNotificationBag(NotificationTaskBag $notificationTaskBag = null): TaskInterface;
+    public function afterExecutingNotificationBag(?NotificationTaskBag $notificationTaskBag = null): TaskInterface;
 
     public function getAfterExecutingNotificationBag(): ?NotificationTaskBag;
 
@@ -187,7 +187,7 @@ interface TaskInterface
      */
     public function getAfterExecuting(): callable|array|null;
 
-    public function setDescription(string $description = null): self;
+    public function setDescription(?string $description = null): self;
 
     public function getDescription(): ?string;
 
@@ -195,17 +195,17 @@ interface TaskInterface
 
     public function getExpression(): string;
 
-    public function setExecutionAbsoluteDeadline(DateInterval $dateInterval = null): self;
+    public function setExecutionAbsoluteDeadline(?DateInterval $dateInterval = null): self;
 
     public function getExecutionAbsoluteDeadline(): ?DateInterval;
 
     public function getExecutionComputationTime(): ?float;
 
-    public function setExecutionComputationTime(float $executionComputationTime = null): self;
+    public function setExecutionComputationTime(?float $executionComputationTime = null): self;
 
     public function getExecutionDelay(): ?int;
 
-    public function setExecutionDelay(int $executionDelay = null): self;
+    public function setExecutionDelay(?int $executionDelay = null): self;
 
     public function getExecutionMemoryUsage(): int;
 
@@ -213,34 +213,34 @@ interface TaskInterface
 
     public function getExecutionPeriod(): ?float;
 
-    public function setExecutionPeriod(float $executionPeriod = null): self;
+    public function setExecutionPeriod(?float $executionPeriod = null): self;
 
     public function getExecutionRelativeDeadline(): ?DateInterval;
 
-    public function setExecutionRelativeDeadline(DateInterval $dateInterval = null): self;
+    public function setExecutionRelativeDeadline(?DateInterval $dateInterval = null): self;
 
-    public function setExecutionStartDate(string $executionStartDate = null): self;
+    public function setExecutionStartDate(?string $executionStartDate = null): self;
 
     /**
      * Return the date from which the task is allowed to be executed / considered as "due".
      */
     public function getExecutionStartDate(): ?DateTimeImmutable;
 
-    public function setExecutionEndDate(string $executionEndDate = null): self;
+    public function setExecutionEndDate(?string $executionEndDate = null): self;
 
     /**
      * Return the date until which the task is allowed to be executed / considered as "due".
      */
     public function getExecutionEndDate(): ?DateTimeImmutable;
 
-    public function setExecutionStartTime(DateTimeImmutable $dateTimeImmutable = null): self;
+    public function setExecutionStartTime(?DateTimeImmutable $dateTimeImmutable = null): self;
 
     /**
      * Return the date since the task started to being executed.
      */
     public function getExecutionStartTime(): ?DateTimeImmutable;
 
-    public function setExecutionEndTime(DateTimeImmutable $dateTimeImmutable = null): self;
+    public function setExecutionEndTime(?DateTimeImmutable $dateTimeImmutable = null): self;
 
     /**
      * Return the date since the task stopped to being executed.
@@ -259,25 +259,25 @@ interface TaskInterface
      */
     public function getAccessLockBag(): ?AccessLockBag;
 
-    public function setLastExecution(DateTimeImmutable $dateTimeImmutable = null): self;
+    public function setLastExecution(?DateTimeImmutable $dateTimeImmutable = null): self;
 
     public function getLastExecution(): ?DateTimeImmutable;
 
-    public function setMaxDuration(float $maxDuration = null): self;
+    public function setMaxDuration(?float $maxDuration = null): self;
 
     public function getMaxDuration(): ?float;
 
-    public function setMaxExecutions(int $maxExecutions = null): TaskInterface;
+    public function setMaxExecutions(?int $maxExecutions = null): TaskInterface;
 
     public function getMaxExecutions(): ?int;
 
-    public function setMaxRetries(int $maxRetries = null): TaskInterface;
+    public function setMaxRetries(?int $maxRetries = null): TaskInterface;
 
     public function getMaxRetries(): ?int;
 
     public function getNice(): ?int;
 
-    public function setNice(int $nice = null): self;
+    public function setNice(?int $nice = null): self;
 
     public function get(string $key, mixed $default = null): mixed;
 
@@ -297,7 +297,7 @@ interface TaskInterface
      *
      * @throws InvalidArgumentException If the state is not allowed.
      */
-    public function setExecutionState(string $executionState = null): self;
+    public function setExecutionState(?string $executionState = null): self;
 
     public function isOutput(): bool;
 
@@ -341,7 +341,7 @@ interface TaskInterface
 
     public function getTimezone(): ?DateTimeZone;
 
-    public function setTimezone(DateTimeZone $dateTimeZone = null): self;
+    public function setTimezone(?DateTimeZone $dateTimeZone = null): self;
 
     public function isTracked(): bool;
 

--- a/src/Transport/Dsn.php
+++ b/src/Transport/Dsn.php
@@ -88,7 +88,7 @@ final class Dsn
         return $this->password;
     }
 
-    public function getPort(int $default = null): ?int
+    public function getPort(?int $default = null): ?int
     {
         return $this->port ?? $default;
     }

--- a/tests/DependencyInjection/SchedulerBundleExtensionTest.php
+++ b/tests/DependencyInjection/SchedulerBundleExtensionTest.php
@@ -2309,7 +2309,7 @@ final class SchedulerBundleExtensionTest extends TestCase
     /**
      * @param array<string, mixed> $configuration
      */
-    private function getContainer(array $configuration = [], Closure $extraDefinitions = null, Closure $extraPasses = null): ContainerBuilder
+    private function getContainer(array $configuration = [], ?Closure $extraDefinitions = null, ?Closure $extraPasses = null): ContainerBuilder
     {
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->registerExtension(new SchedulerBundleExtension());


### PR DESCRIPTION
| Q                | A
| ---------------- | ---
| PHP version?     | 8.4.1
| Bundle version?  | 0.10.4
| Symfony version? | /
| New feature?     | no
| Bug fix?         | yes
| Discussion?      | /

# Context

This PR fixes the implicit nullable deprecation thrown in PHP 8.4 (see https://wiki.php.net/rfc/deprecate-implicitly-nullable-types).

I hope I found them all :sweat_smile: 